### PR TITLE
Add test for latest endpoint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1357,6 +1357,34 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sqlalchemy-utils"
+version = "0.41.2"
+description = "Various utility functions for SQLAlchemy."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "SQLAlchemy-Utils-0.41.2.tar.gz", hash = "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"},
+    {file = "SQLAlchemy_Utils-0.41.2-py3-none-any.whl", hash = "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e"},
+]
+
+[package.dependencies]
+SQLAlchemy = ">=1.3"
+
+[package.extras]
+arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
+encrypted = ["cryptography (>=0.6)"]
+intervals = ["intervals (>=0.7.1)"]
+password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["Jinja2 (>=2.3)", "Pygments (>=1.2)", "backports.zoneinfo", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "isort (>=4.2.2)", "pg8000 (>=1.12.4)", "psycopg (>=3.1.8)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (==7.4.4)", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+test-all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "backports.zoneinfo", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg (>=3.1.8)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (==7.4.4)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
+
+[[package]]
 name = "starlette"
 version = "0.37.2"
 description = "The little ASGI library that shines."
@@ -1788,4 +1816,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<4.0"
-content-hash = "739cd03c462b318e2f153dccbd18f18f6bec722a7886c038833bdffb0189337a"
+content-hash = "1278dc2b2591331754bf9f455e1d5cb4b35e6886631485410367fa699a7d0b29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pre-commit = "^3.7.1"
 tox = "^4.15.0"
 pytest-randomly = "^3.15.0"
 pytest-sugar = "^1.0.0"
+sqlalchemy-utils = "^0.41.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,30 @@
 """Tests for the main module."""
 
-from fastapi.testclient import TestClient
+from datetime import datetime
 
-from cid.main import app
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy_utils import drop_database
+
+from cid.main import app, get_db, latest_aws_image
+from cid.models import AwsImage
+
+# Create an in-memory SQLite database for testing
+DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
 
 # Create a TestClient instance to test the FastAPI app
 # https://fastapi.tiangolo.com/tutorial/testing/
@@ -14,3 +36,38 @@ def test_read_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"Hello": "World"}
+
+
+def teardown():
+    AwsImage.metadata.drop_all(bind=engine)
+    TestingSessionLocal.remove()
+    engine.dispose()
+
+
+def test_latest_aws_image():
+    AwsImage.metadata.create_all(bind=engine)
+
+    db = TestingSessionLocal()
+    aws_image = AwsImage(
+        id="ami-12345678",
+        name="test_image",
+        version="1.0",
+        # SQLite only supports datetime objects
+        date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+        region="us-west-1",
+        imageId="ami-12345678",
+    )
+    db.add(aws_image)
+    db.commit()
+
+    response = latest_aws_image(db)
+
+    assert response == {
+        "name": "test_image",
+        "version": "1.0",
+        "date": datetime(2022, 1, 1, 0, 0),
+        "amis": {"us-west-1": "ami-12345678"},
+    }
+
+    drop_database(engine.url)
+    app.dependency_overrides.pop(get_db)


### PR DESCRIPTION
A proposal for testing the CIDv2 endpoints.
AWS only, other providers will follow once we've decided on a test strategy. 

Changes:
Add db session generation to dependency function
Add inmemory SQLite DB for testing
Add /latest endpoint testcase