### PR TITLE
Restore creationDate and add AWS endpoints

### DIFF
--- a/cid/crud.py
+++ b/cid/crud.py
@@ -116,6 +116,7 @@ def import_aws_images(db: Session, images: list) -> None:
             "provider": image.get("ImageOwnerAlias"),
             "region": image.get("Region"),
             "description": image.get("Description"),
+            "creationDate": creation_date,
             "deprecationTime": deprecation_time,
         }
         import_queue.append(image_dict)

--- a/cid/models.py
+++ b/cid/models.py
@@ -20,6 +20,7 @@ class AwsImage(Base):
     provider = Column(String)
     region = Column(String)
     description = Column(String)
+    creationDate = Column(DateTime)
     deprecationTime = Column(DateTime)
 
 

--- a/tests/data/aws.json
+++ b/tests/data/aws.json
@@ -349,5 +349,17221 @@
         "BootMode": "uefi-preferred",
         "DeprecationTime": "2026-01-04T18:05:59.000Z",
         "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T01:32:13.000Z",
+        "ImageId": "ami-00fc5931e9367dbc8",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-029a57be6604eac33",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:32:13.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-25T06:45:22.000Z",
+        "ImageId": "ami-010f64ca902894360",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d48c03b7c9e30a2d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T06:45:22.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-25T06:45:21.000Z",
+        "ImageId": "ami-0126c5092316dcd10",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240117-arm64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0922f29df046f2673",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240117-arm64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T06:45:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T13:38:34.000Z",
+        "ImageId": "ami-013f607d678d610d8",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f0098842b1656ac3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T13:38:34.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-19T21:27:25.000Z",
+        "ImageId": "ami-016178b7df46d87f7",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0dfbda569c5f94963",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-19T21:27:25.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T10:53:12.000Z",
+        "ImageId": "ami-01648082d60380363",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b0526dc99df76381",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T10:53:12.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-02-15T03:07:37.000Z",
+        "ImageId": "ami-016fcb84b77101707",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-093649c62f4d1036b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-02-15T03:07:37.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-05T16:53:55.000Z",
+        "ImageId": "ami-017e2978f5f3d9b04",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b5fae48477bd3a1d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T16:53:55.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T07:07:08.000Z",
+        "ImageId": "ami-01811be9ea0491140",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0938445aa26589958",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T07:07:08.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-29T15:21:34.000Z",
+        "ImageId": "ami-0198aea85e52486f9",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08df4208eb27a3828",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-29T15:21:34.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-01T23:51:07.000Z",
+        "ImageId": "ami-01bf42dd371fc0e3b",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e6b5f8af90c5cba7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T23:51:07.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-15T21:46:52.000Z",
+        "ImageId": "ami-01de01a08fffc7c29",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08fd31c5909c1e2cf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T21:46:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T13:20:31.000Z",
+        "ImageId": "ami-01eb758f924608ef7",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-090f95d4f9bd7e756",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T13:20:31.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-31T04:25:47.000Z",
+        "ImageId": "ami-01eee059df76bf24d",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04e230c661e4f41b3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-31T04:25:47.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-28T13:00:02.000Z",
+        "ImageId": "ami-01fb06d62ff3d551d",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02009e6a20a2f64cd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T13:00:02.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-21T11:47:58.000Z",
+        "ImageId": "ami-01fcc08c3d854f3ee",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230419-arm64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-057fb1496ec60dbcd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230419-arm64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T11:47:58.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T09:08:13.000Z",
+        "ImageId": "ami-021ccb412176e7748",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d9787ebf60ec92a2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T09:08:13.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-21T19:58:00.000Z",
+        "ImageId": "ami-023f14610b1b3dcb6",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0af06f9414a9105d8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-21T19:58:00.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T17:32:18.000Z",
+        "ImageId": "ami-02829e3b63b856306",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a1abe76752e02fed",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T17:32:18.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-10-11T03:02:21.000Z",
+        "ImageId": "ami-028aaf6cee5c53d19",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07bb61799608a1e30",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T03:02:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-22T15:04:11.000Z",
+        "ImageId": "ami-02abf88e02510f9ce",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM_BETA-20230228-x86_64-22-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00af26eb72c9f06c6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM_BETA-20230228-x86_64-22-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-22T15:04:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T01:48:59.000Z",
+        "ImageId": "ami-02b9525e69f34453a",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-048723ed42f8d0cc7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T01:48:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T11:28:04.000Z",
+        "ImageId": "ami-02bffd01fe599570f",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06eebd1ba67b8392d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T11:28:04.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T19:23:29.000Z",
+        "ImageId": "ami-02c1323b15ae00953",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cd418be886ab781e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T19:23:29.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-06T05:01:57.000Z",
+        "ImageId": "ami-02dd88f61b579200f",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0423fea7e9df11fc6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T05:01:57.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-24T14:01:58.000Z",
+        "ImageId": "ami-02e62987e1d46a09c",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM_BETA-20230306-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ba096132906d3497",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM_BETA-20230306-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-24T14:01:58.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-27T14:51:34.000Z",
+        "ImageId": "ami-02ef4ad0f94b6fee4",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2c38af4c2336fb9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-27T14:51:34.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-06T04:48:15.000Z",
+        "ImageId": "ami-03120584f923cba88",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03c20e0442911342e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T04:48:15.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-21T14:38:28.000Z",
+        "ImageId": "ami-0339ddbb6d0b29c62",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230418-arm64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-045564d62331bbd38",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230418-arm64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T14:38:28.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-09-21T10:08:02.000Z",
+        "ImageId": "ami-036468a96341b30d8",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f1f7702e52a09db3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T10:08:02.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-11T00:40:44.000Z",
+        "ImageId": "ami-0364baec6aa5c0b73",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-046cb6631bfa64e1a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T00:40:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-03T17:19:11.000Z",
+        "ImageId": "ami-03a53d58ec04750f8",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0742d8dbc9da49a6b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T17:19:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T20:57:37.000Z",
+        "ImageId": "ami-03b28d819714baf4b",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0378228ce1a0e25f1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T20:57:37.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-31T18:40:56.000Z",
+        "ImageId": "ami-03b4a7a9322996d1b",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04e208d5f95f65acd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T18:40:56.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-01T23:25:17.000Z",
+        "ImageId": "ami-03db96a209c221af9",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ffc2811e09387dc4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T23:25:17.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-02T08:03:07.000Z",
+        "ImageId": "ami-03ea5f77dd9903f50",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01ebd85d951d484bf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-02T08:03:07.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-29T01:26:16.000Z",
+        "ImageId": "ami-03ecc14740116f38a",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240521-arm64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03a601132aefb776b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240521-arm64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T01:26:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T19:08:16.000Z",
+        "ImageId": "ami-040610550f21d60e7",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ac72054d26a6618e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T19:08:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T05:27:49.000Z",
+        "ImageId": "ami-0407828649f712d74",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08570d07fbd14fda7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-05T05:27:49.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-12-07T19:31:50.000Z",
+        "ImageId": "ami-040f0df296275ae3f",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e1765b3710a92d61",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-12-07T19:31:50.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-15T01:26:22.000Z",
+        "ImageId": "ami-041db1e4f2aea545d",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240312-arm64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ff78a60372ce9ccc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240312-arm64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T01:26:22.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T15:23:01.000Z",
+        "ImageId": "ami-043ed45fe0d296d3c",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0378a2b2a9e5fe4cc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T15:23:01.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T17:12:48.000Z",
+        "ImageId": "ami-0446ee3992dd566c3",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07a61d6802e7b9be9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T17:12:48.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T15:05:08.000Z",
+        "ImageId": "ami-046243dd08fb2a485",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2ce05b0c8ce8c69",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T15:05:08.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-10T01:51:03.000Z",
+        "ImageId": "ami-04703e81046c0ea3a",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0230fd297a2e45567",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-10T01:51:03.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-22T15:05:42.000Z",
+        "ImageId": "ami-049e7074646c52dcd",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c32ddd41e1a68e95",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-22T15:05:42.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-22T15:14:45.000Z",
+        "ImageId": "ami-04ce2b5d28b7e9e38",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM_BETA-20230912-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-096860ff12e4b78f1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM_BETA-20230912-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-09-22T15:14:45.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-06T18:26:28.000Z",
+        "ImageId": "ami-051e25449cf8f80a0",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e0c9076e12aac21b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-06T18:26:28.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-06T23:33:28.000Z",
+        "ImageId": "ami-0520f659e63241c65",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-064c26ab24a60f4d1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T23:33:28.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-24T09:38:50.000Z",
+        "ImageId": "ami-0526183d57c39295f",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240419-arm64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00d8a2552ee6349eb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240419-arm64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T09:38:50.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-15T23:00:44.000Z",
+        "ImageId": "ami-052c95c6b2c3ba37e",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231115-arm64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09dc502445e922311",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231115-arm64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-15T23:00:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-13T23:27:21.000Z",
+        "ImageId": "ami-05353053eb86eb325",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0625eb79c51e0320e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T23:27:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-24T01:11:21.000Z",
+        "ImageId": "ami-055db51e85eca5867",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ea5c59ddce57f5df",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:11:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-18T17:01:52.000Z",
+        "ImageId": "ami-0596d1f46484392fb",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0419eb429333f8015",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T17:01:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T15:45:28.000Z",
+        "ImageId": "ami-05c9c9249c0f6fc84",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0653f4daad9656784",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T15:45:28.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T09:00:36.000Z",
+        "ImageId": "ami-05d3308aa385a263b",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f010c9b255c10061",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T09:00:36.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-29T08:17:35.000Z",
+        "ImageId": "ami-05f1d48c1e5f4e607",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e8c4267905dd1523",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T08:17:35.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T19:37:33.000Z",
+        "ImageId": "ami-05f62323c9870d475",
+        "ImageLocation": "amazon/RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-096565133fd5ee4b0",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T19:37:33.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-15T01:28:06.000Z",
+        "ImageId": "ami-063d7b67e9396edd5",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0179510d08db4f58d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T01:28:06.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-11T03:06:59.000Z",
+        "ImageId": "ami-065fdb87e8340beb1",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ea76cc646d068da4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T03:06:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T15:08:32.000Z",
+        "ImageId": "ami-0662d91d582f05143",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ad8a374935cb42a8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T15:08:32.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-26T15:59:56.000Z",
+        "ImageId": "ami-066ef6008e83b5cca",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0655b4b200cdc3fbe",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T15:59:56.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T12:29:24.000Z",
+        "ImageId": "ami-0682b229c911836c0",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0922e5bc0abd2760e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-09T12:29:24.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T19:22:15.000Z",
+        "ImageId": "ami-0686ca4079daa3fb4",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02e42b44b7b8d9c83",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T19:22:15.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-04T21:06:49.000Z",
+        "ImageId": "ami-06988e8608a0b17cd",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240229-arm64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-005f15dc8d2bcd254",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240229-arm64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T21:06:49.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T14:55:09.000Z",
+        "ImageId": "ami-069db5f1c20a2686f",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05be1b0627ef0a068",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T14:55:09.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-12-07T19:32:16.000Z",
+        "ImageId": "ami-06a28d425606fb54c",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231207-arm64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-002e7c3aaae4a695c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231207-arm64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-12-07T19:32:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-28T03:10:05.000Z",
+        "ImageId": "ami-06a307332137951a9",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-035e769b6f64e6310",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-28T03:10:05.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-15T01:27:33.000Z",
+        "ImageId": "ami-06c3df3a629266e11",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0acf44804b9422fcd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T01:27:33.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-10T01:50:44.000Z",
+        "ImageId": "ami-06ce5f51b2ed65cd4",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230307-arm64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c32810ffa04cf103",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230307-arm64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-10T01:50:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-07T19:42:26.000Z",
+        "ImageId": "ami-06cef80059b5663c0",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08217f78000216169",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T19:42:26.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-20T18:59:16.000Z",
+        "ImageId": "ami-06d2cfdeb1249f74b",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0414652c595ff3f9c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T18:59:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T11:43:53.000Z",
+        "ImageId": "ami-06f7bf9be97e136c8",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04c212bd1c74f4415",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T11:43:53.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-23T23:24:32.000Z",
+        "ImageId": "ami-07019b544e2bbaa3d",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b95913ba9a86ead4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-23T23:24:32.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-29T15:21:51.000Z",
+        "ImageId": "ami-071098b1c6e597f4e",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06b39b5f78908aa65",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-29T15:21:51.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-21T19:55:51.000Z",
+        "ImageId": "ami-074cb1cbf1c9e8378",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231114-arm64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07ed1c6ba97904e74",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231114-arm64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-21T19:55:51.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T11:26:58.000Z",
+        "ImageId": "ami-0780576b3d3d47248",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00df818eb13f4a9d5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T11:26:58.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-25T19:06:39.000Z",
+        "ImageId": "ami-078ae0a3d9df04091",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230822-arm64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b5fa2cf44e1db608",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230822-arm64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T19:06:39.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-29T15:20:30.000Z",
+        "ImageId": "ami-07905e07b27e60af0",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01c8024174954d8c2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-29T15:20:30.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-16T20:54:44.000Z",
+        "ImageId": "ami-07cf4e8e1da43b88c",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20231115-arm64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0244f65721ac795a9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20231115-arm64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T20:54:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-13T00:10:05.000Z",
+        "ImageId": "ami-07cf987663da7010b",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM_BETA-20240412-x86_64-55-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-050c4ab1b39469be8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM_BETA-20240412-x86_64-55-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-13T00:10:05.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-02T08:03:16.000Z",
+        "ImageId": "ami-07df94372d48856e3",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e12e45b0d232b39d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-02T08:03:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-09-21T14:40:08.000Z",
+        "ImageId": "ami-07e9c60d679b6a8ac",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02bac13d08d630b9e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T14:40:08.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-11T23:46:34.000Z",
+        "ImageId": "ami-08109f3fc8840f893",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM_BETA-20240411-arm64-30-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fb86745ac1e3032d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM_BETA-20240411-arm64-30-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-11T23:46:34.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-24T08:31:23.000Z",
+        "ImageId": "ami-0816e25567f1b3cff",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240423-arm64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00ffddbd50c4ae6e3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240423-arm64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T08:31:23.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-06T04:45:53.000Z",
+        "ImageId": "ami-08231a6388e832377",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ea93bfb8702caadb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T04:45:53.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T11:19:33.000Z",
+        "ImageId": "ami-0828c495d081a6cb7",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d5b456b5aa879d42",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T11:19:33.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-15T23:00:47.000Z",
+        "ImageId": "ami-084ae17a60de350bc",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-095dd553b5060d749",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-15T23:00:47.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-26T01:55:35.000Z",
+        "ImageId": "ami-08507487485486fde",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230823-arm64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07998eb2f77148252",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230823-arm64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-26T01:55:35.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T21:45:44.000Z",
+        "ImageId": "ami-08649852dde3aa021",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04bb1afff26cdec2e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T21:45:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T02:26:07.000Z",
+        "ImageId": "ami-086669870e5b62974",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f010f6f3eab98344",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T02:26:07.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-02-20T22:31:14.000Z",
+        "ImageId": "ami-08874c9ba178616a1",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230215-arm64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01702e08ff6e4e3f6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230215-arm64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T22:31:14.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-04T03:37:15.000Z",
+        "ImageId": "ami-0891a6d2b2e5ef5b7",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0306fbe020ef50650",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-04T03:37:15.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-02-15T02:48:27.000Z",
+        "ImageId": "ami-0895aabac9ac0d200",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c45c97b5c310e6bf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-02-15T02:48:27.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-06T21:40:18.000Z",
+        "ImageId": "ami-08a20c15f394e5531",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a216c8d1d9b2358e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-06T21:40:18.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T01:39:16.000Z",
+        "ImageId": "ami-08a62ed708348b47a",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c897124e7ece3ad6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:39:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-26T15:59:42.000Z",
+        "ImageId": "ami-08a8728b7fbf38c8b",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01d9f5a6effcdf1a6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T15:59:42.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-20T22:30:52.000Z",
+        "ImageId": "ami-08b489494d801c6d0",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01833ef546bfb9667",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T22:30:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-22T17:41:20.000Z",
+        "ImageId": "ami-08c2f35089eeeb4b1",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0443f3eaaa2c1ac02",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-09-22T17:41:20.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-31T01:36:48.000Z",
+        "ImageId": "ami-08c9959209c170aed",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0eb27f80e99dd23f7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-31T01:36:48.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-15T00:17:16.000Z",
+        "ImageId": "ami-08decea89a6baaa65",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ac3106dabf171e9d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-15T00:17:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-04T17:50:17.000Z",
+        "ImageId": "ami-08ea36281b43b3dca",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ba4ebdce85aee24d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-04T17:50:17.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-28T03:00:46.000Z",
+        "ImageId": "ami-090635bcd35103104",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20231127-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f72571d8ad2d3c01",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20231127-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-28T03:00:46.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-11T00:40:06.000Z",
+        "ImageId": "ami-090e071a700c016e4",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-083e1f2517ebb4f83",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T00:40:06.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-10T11:27:01.000Z",
+        "ImageId": "ami-0914e31294a743efb",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20231101-arm64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0500b413cbdf9d271",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20231101-arm64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-10T11:27:01.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-09T12:29:04.000Z",
+        "ImageId": "ami-09196946a8c1fe659",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0222b648ca0d2ddc2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T12:29:04.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-14T05:27:04.000Z",
+        "ImageId": "ami-0928ce4eb960c93d4",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02f302799755ba782",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T05:27:04.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-02-15T02:47:12.000Z",
+        "ImageId": "ami-093afb7914cee5bd6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0499bccae5ac8b464",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-02-15T02:47:12.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-06T21:24:11.000Z",
+        "ImageId": "ami-0942a98ed4dd428f4",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03fa51476b4bb5071",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-06T21:24:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-15T21:48:30.000Z",
+        "ImageId": "ami-0944c2812e719cec6",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b74e2c15c2bea6b8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T21:48:30.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-22T15:01:29.000Z",
+        "ImageId": "ami-096d2e8ed59f80537",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09c27791a3edaff80",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-22T15:01:29.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-15T01:28:47.000Z",
+        "ImageId": "ami-098e76148774c1af6",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e050837d4ed7366f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-15T01:28:47.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-11T23:47:17.000Z",
+        "ImageId": "ami-09a0ab8ebe952d86f",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM_BETA-20240411-x86_64-30-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05cbd5d50ddf0ed9c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM_BETA-20240411-x86_64-30-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-11T23:47:17.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-25T07:13:59.000Z",
+        "ImageId": "ami-09a93ec324b72665d",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cbaa0f1855469a70",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T07:13:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-31T04:27:59.000Z",
+        "ImageId": "ami-09b59dcf57bac929c",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-041e4025023ae3c87",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-31T04:27:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-07T19:08:39.000Z",
+        "ImageId": "ami-09bde318318ea0633",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230802-arm64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03b008bafd5274786",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230802-arm64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T19:08:39.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T09:58:35.000Z",
+        "ImageId": "ami-0a04ebc33b01c859a",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0dcffe7ec66fc46e7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T09:58:35.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-28T20:55:51.000Z",
+        "ImageId": "ami-0a0513d6f7ed33d4b",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c4a96cba9b50f40f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-28T20:55:51.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-15T23:02:36.000Z",
+        "ImageId": "ami-0a095dfcb02a9aef5",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03adbb66f2b1b15f4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-15T23:02:36.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-31T17:14:03.000Z",
+        "ImageId": "ami-0a10725be8e755aeb",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e815919df0406297",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T17:14:03.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-06T21:38:36.000Z",
+        "ImageId": "ami-0a37c4a29483b788c",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04e18f07691ee8df4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-06T21:38:36.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-23T23:24:11.000Z",
+        "ImageId": "ami-0a57d461ef1a5c298",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05f7b68af96d47276",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-23T23:24:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-16T05:30:15.000Z",
+        "ImageId": "ami-0a68ff13f7990e26a",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM-20240514-arm64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06831ce13b5078f8c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM-20240514-arm64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-16T05:30:15.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-16T05:30:07.000Z",
+        "ImageId": "ami-0a833f2e2fd4ef828",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-019ae71dd5992594c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-05-16T05:30:07.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T21:19:21.000Z",
+        "ImageId": "ami-0a86c88472539f597",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d81e856c3b47ab7a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T21:19:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-09T22:15:18.000Z",
+        "ImageId": "ami-0aa9992bce70b7f6a",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-094c35396d78524ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T22:15:18.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-26T15:32:41.000Z",
+        "ImageId": "ami-0aaff3cc51d3a615a",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230623-arm64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0330b2169e2bfd92c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230623-arm64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T15:32:41.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-16T05:46:10.000Z",
+        "ImageId": "ami-0abfb8069a36a429b",
+        "ImageLocation": "amazon/RHEL_HA-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a6ef9a5a3a749cbb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-05-16T05:46:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-23T23:20:01.000Z",
+        "ImageId": "ami-0ac4188484b359bd6",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240117-arm64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-081b759418defe3a1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240117-arm64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-23T23:20:01.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-12-07T19:36:19.000Z",
+        "ImageId": "ami-0acbfd7b157c545b9",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07276aa70312475e2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-12-07T19:36:19.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-06T18:06:06.000Z",
+        "ImageId": "ami-0af189f5339b678ed",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-020edd787d4b788ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-06T18:06:06.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-15T00:18:56.000Z",
+        "ImageId": "ami-0b024d2edb393e82d",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0490ef03d60c57f1f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-15T00:18:56.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-05T06:26:57.000Z",
+        "ImageId": "ami-0b1377d83ff2a95cc",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240229-arm64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a52069537fa93011",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240229-arm64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T06:26:57.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-26T02:12:11.000Z",
+        "ImageId": "ami-0b13ef11c79efdbee",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0714cbb57e41c9a5f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-26T02:12:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-04T02:47:21.000Z",
+        "ImageId": "ami-0b18a6ac17fcb27ce",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0403831a2fe134610",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-04T02:47:21.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-15T22:30:51.000Z",
+        "ImageId": "ami-0b2352b666c6ec256",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04a15f3ff61bb8c7f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T22:30:51.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T17:08:57.000Z",
+        "ImageId": "ami-0b2c67e83f833293e",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-060fac5efe24d5fe3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T17:08:57.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-31T05:06:16.000Z",
+        "ImageId": "ami-0b35eb5e03e633ab1",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cdb77361a0fedb94",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-31T05:06:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T13:46:53.000Z",
+        "ImageId": "ami-0b36150cce6daf942",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-022d7c67e9530d81d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T13:46:53.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T08:45:54.000Z",
+        "ImageId": "ami-0b386591350de98bc",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-043d0f63eb6eb433f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-24T08:45:54.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T18:47:52.000Z",
+        "ImageId": "ami-0b656fa850717eb2c",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0144df8ee5310533e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T18:47:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T08:36:52.000Z",
+        "ImageId": "ami-0b738007a38f840d8",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f74e55c54d6fbb0d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-24T08:36:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-04T19:41:37.000Z",
+        "ImageId": "ami-0b73a4bd4c0b63f35",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b0713e9585a7c6b9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T19:41:37.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-10-04T02:47:16.000Z",
+        "ImageId": "ami-0b7c05c989ed2c2fc",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231003-arm64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00563379543764154",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231003-arm64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-04T02:47:16.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-28T14:46:10.000Z",
+        "ImageId": "ami-0b92598545410e0cb",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0891934c21ce5cdc8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-28T14:46:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-24T14:01:59.000Z",
+        "ImageId": "ami-0b927227c7188b5ad",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM_BETA-20230306-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04dcd499bc62c5411",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM_BETA-20230306-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-24T14:01:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-10T14:56:39.000Z",
+        "ImageId": "ami-0b9e3c0cc92a77621",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e8b56070515cdd67",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T14:56:39.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-10T15:15:46.000Z",
+        "ImageId": "ami-0ba7ef923dc19ccc0",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06fc54f1aac874549",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T15:15:46.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-05T16:30:19.000Z",
+        "ImageId": "ami-0bb9d960619db6fd8",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08f8fdf166a8bad71",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T16:30:19.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-22T17:41:10.000Z",
+        "ImageId": "ami-0bc32fdb12dca7c35",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM_BETA-20230914-arm64-63-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-092b15664f5a32590",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM_BETA-20230914-arm64-63-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-22T17:41:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-05-03T15:04:00.000Z",
+        "ImageId": "ami-0bffd3cc5a011e1a8",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06a21d3d614f11b40",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T15:04:00.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-06T23:00:27.000Z",
+        "ImageId": "ami-0c0890972038abc25",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-043747555caf4409f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T23:00:27.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-07T19:11:33.000Z",
+        "ImageId": "ami-0c11bdbc82feb0661",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-044a62d267e319f34",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T19:11:33.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T09:41:05.000Z",
+        "ImageId": "ami-0c5e3d5b31dfc9a85",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09ab9643680aecdc8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T09:41:05.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-02T19:16:14.000Z",
+        "ImageId": "ami-0c6e058a9eee76dc7",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03ca0c4a9afd7b827",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-02T19:16:14.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-05-10T14:53:39.000Z",
+        "ImageId": "ami-0c73e0d1594f19fff",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230503-arm64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e529a20167ecffdc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230503-arm64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T14:53:39.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T19:59:10.000Z",
+        "ImageId": "ami-0cb0c1d51d5a41c82",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00795f40df216526b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T19:59:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T20:01:01.000Z",
+        "ImageId": "ami-0cb827379ead2368f",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0540d7db9b43e037f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T20:01:01.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T20:28:22.000Z",
+        "ImageId": "ami-0cc08bd0e29a9af4b",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0681f2134e26ec650",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T20:28:22.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-01T22:42:10.000Z",
+        "ImageId": "ami-0cdfb6f22e6c84c0e",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-010e6c8506a8c81fc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T22:42:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-13T23:27:15.000Z",
+        "ImageId": "ami-0d0bc98d27823f70c",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-053e04255ed0b3cb3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T23:27:15.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-04T17:48:57.000Z",
+        "ImageId": "ami-0d1cda58343758de6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240103-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04526141729cc4e15",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240103-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-04T17:48:57.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-11T03:14:59.000Z",
+        "ImageId": "ami-0d1dec043154623ec",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d042c8a20e8dd0a7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T03:14:59.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T23:43:51.000Z",
+        "ImageId": "ami-0d362dae861b477dd",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0724a853e405e0f48",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T23:43:51.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T11:41:53.000Z",
+        "ImageId": "ami-0d37cccd08e27709b",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c0ed0fed89f945c1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T11:41:53.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-11T00:12:17.000Z",
+        "ImageId": "ami-0d449f7957c61cdef",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0095a6022d15ca096",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T00:12:17.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-06T23:02:19.000Z",
+        "ImageId": "ami-0d45fb2fd1e7613be",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01b70dcfa680891c7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T23:02:19.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T14:54:30.000Z",
+        "ImageId": "ami-0d70dbc3fbc225db7",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b4d6cc28e60c4615",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T14:54:30.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T20:44:03.000Z",
+        "ImageId": "ami-0da727e99f5e86cfc",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0476ab14e46ca0959",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T20:44:03.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-14T05:26:29.000Z",
+        "ImageId": "ami-0db8086ce466d9993",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05ef3b51081386a4e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T05:26:29.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-18T20:42:41.000Z",
+        "ImageId": "ami-0e14575c508c23fbc",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230712-arm64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-076bf6947556acd59",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230712-arm64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T20:42:41.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T06:29:52.000Z",
+        "ImageId": "ami-0e475c4f6de12961a",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05ea64810f39f61e4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T06:29:52.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T14:38:24.000Z",
+        "ImageId": "ami-0e4b92b89062d7db7",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b99e5f77fc2bb0d1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T14:38:24.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T15:53:11.000Z",
+        "ImageId": "ami-0e6d13f4cc3d72be7",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0364890a4f4c44848",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T15:53:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T12:26:10.000Z",
+        "ImageId": "ami-0e96650c715733191",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-011aa38bf67c7d6e5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-09T12:26:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-21T20:09:12.000Z",
+        "ImageId": "ami-0ea423af28a3f8661",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-009e7747005aff32f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-21T20:09:12.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-31T18:42:07.000Z",
+        "ImageId": "ami-0eaa0dbee28581453",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0622e75a319e92e72",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T18:42:07.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T04:24:29.000Z",
+        "ImageId": "ami-0eb4ecadc6f00aa18",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01ddabdd6b7936f75",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-05T04:24:29.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-19T21:36:09.000Z",
+        "ImageId": "ami-0edc6351c958da474",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230118-arm64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b9dfe4d7e6ca725d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230118-arm64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-19T21:36:09.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T21:09:50.000Z",
+        "ImageId": "ami-0f03ab0d77d09f69b",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-067829487e08d6065",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T21:09:50.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T21:35:31.000Z",
+        "ImageId": "ami-0f11f7a4509b3d266",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c89faf2e7baaedcf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T21:35:31.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T20:53:10.000Z",
+        "ImageId": "ami-0f1723fa967a342c1",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0394ada624574c87a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T20:53:10.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T13:10:37.000Z",
+        "ImageId": "ami-0f566d4f29ca371c5",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09748644287e979f9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T13:10:37.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-30T23:46:46.000Z",
+        "ImageId": "ami-0f59f0396f1dda7a1",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230125-arm64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00c9d86263ecd75e9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230125-arm64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T23:46:46.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-13T23:27:28.000Z",
+        "ImageId": "ami-0f5b4a2252558237d",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0da2f6c434cfaae20",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T23:27:28.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-31T17:46:01.000Z",
+        "ImageId": "ami-0f5fe09c9dca6a432",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2e504eb6e7f2b9b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-31T17:46:01.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-31T00:33:20.000Z",
+        "ImageId": "ami-0f87758d47f9c346f",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b0d30c96aeba1224",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-31T00:33:20.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-26T02:15:11.000Z",
+        "ImageId": "ami-0f8fc90496d4970b8",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fa0633a8d0ede7c4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-26T02:15:11.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T21:19:34.000Z",
+        "ImageId": "ami-0fb78bc7f205f25fb",
+        "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0553a751a1dd41d7c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T21:19:34.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T20:22:08.000Z",
+        "ImageId": "ami-0fe7507703898a688",
+        "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01856b62844c43e45",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T20:22:08.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-05T16:32:44.000Z",
+        "ImageId": "ami-0ffc90047ae4be0c9",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04f0e1688b8e7635d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T16:32:44.000Z",
+        "Region": "af-south-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-09T18:29:25.000Z",
+        "ImageId": "ami-000fa389ccc6668ed",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-063de8dc763c2f71a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T18:29:25.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-25T16:32:38.000Z",
+        "ImageId": "ami-0012ae9e8538facda",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230822-arm64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bac360b9efc4b6a1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230822-arm64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T16:32:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T09:55:20.000Z",
+        "ImageId": "ami-00136cdffa832f1d9",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0611586a3b7ed4bf2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T09:55:20.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-25T15:11:09.000Z",
+        "ImageId": "ami-001becb2e23e5a428",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230823-arm64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0551181853eec1f91",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230823-arm64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T15:11:09.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-02-20T19:20:45.000Z",
+        "ImageId": "ami-002a9f86f891f20ac",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230215-arm64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04e1185dae4590cec",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230215-arm64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T19:20:45.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-13T18:33:52.000Z",
+        "ImageId": "ami-003391ce9645acc53",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06b4a524ef5ef10e7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T18:33:52.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-28T06:45:45.000Z",
+        "ImageId": "ami-003ef16612186b845",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06b3383f127a55a3c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-28T06:45:45.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-15T17:06:43.000Z",
+        "ImageId": "ami-00458377483602a13",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240312-arm64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-067acf7fb4f9f746e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240312-arm64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T17:06:43.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-30T20:09:07.000Z",
+        "ImageId": "ami-0048f49e23e56a4fc",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f2cd706eda79dbde",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-30T20:09:07.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-25T07:20:18.000Z",
+        "ImageId": "ami-007887c78f23ab87c",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b86e1b81c5d0b983",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T07:20:18.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-12T16:43:29.000Z",
+        "ImageId": "ami-00851be57c150f530",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM_BETA-20240412-arm64-55-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0252419110e79de52",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM_BETA-20240412-arm64-55-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-12T16:43:29.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-06T07:04:16.000Z",
+        "ImageId": "ami-00b042b821317ad31",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f7aeee77f0cc1d02",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T07:04:16.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T23:55:06.000Z",
+        "ImageId": "ami-00ba455a863d42543",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08d383fa96ef360e9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T23:55:06.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-03T18:14:40.000Z",
+        "ImageId": "ami-00bbc87a73cf5580c",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04e23db23abd41384",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T18:14:40.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-11T20:13:09.000Z",
+        "ImageId": "ami-00bf1b432f94e0193",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM_BETA-20240411-arm64-30-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-020ecbcabed47ad61",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM_BETA-20240411-arm64-30-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-11T20:13:09.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T11:00:08.000Z",
+        "ImageId": "ami-00c4c03d394dd32aa",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03b0153683bf1b55e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T11:00:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-06T18:10:55.000Z",
+        "ImageId": "ami-00e1587a5ae3033f8",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-020c1651fc692e569",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-06T18:10:55.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T20:42:14.000Z",
+        "ImageId": "ami-00f379feb1dd06a18",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c3c1dc45f9f13b9b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T20:42:14.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-16T23:22:50.000Z",
+        "ImageId": "ami-00fc960ae18c7876b",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20231115-arm64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00dc4d0db1e3d6ebf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20231115-arm64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T23:22:50.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-24T16:09:59.000Z",
+        "ImageId": "ami-01142242f4ec0f077",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240423-arm64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03596251981b76cc0",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240423-arm64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T16:09:59.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-26T17:52:34.000Z",
+        "ImageId": "ami-0123203c5aaddcc96",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0aca5f62ccc2af881",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T17:52:34.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-24T11:09:16.000Z",
+        "ImageId": "ami-012b12b9790d485e1",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240117-arm64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c36a04f0079a6266",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240117-arm64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T11:09:16.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-22T15:49:42.000Z",
+        "ImageId": "ami-012b4f917c997ddb5",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bb322358615a4f13",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-22T15:49:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-16T01:50:00.000Z",
+        "ImageId": "ami-01494a7b10f6abbf5",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231115-arm64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cd366151c88c4371",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231115-arm64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T01:50:00.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-22T14:40:22.000Z",
+        "ImageId": "ami-01525d31edb8d0fb6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02eb07d2bb389dada",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-09-22T14:40:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T16:09:22.000Z",
+        "ImageId": "ami-015b6329a52870148",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-048ab856186d3eff0",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T16:09:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-15T16:04:41.000Z",
+        "ImageId": "ami-017a0461ff7eea83d",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cc23e4d8bb7f01bb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T16:04:41.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-05T01:22:38.000Z",
+        "ImageId": "ami-01b5b5dbe567f137f",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240229-arm64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-069ef9f6bb986df9a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240229-arm64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T01:22:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T17:59:33.000Z",
+        "ImageId": "ami-01bd826a47b9bb964",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-034dc6578c41cc35d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T17:59:33.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T21:17:50.000Z",
+        "ImageId": "ami-01e301d1d766b276b",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00272db82f045294e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T21:17:50.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T07:16:11.000Z",
+        "ImageId": "ami-020f287940a708083",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0de51b2bbf260de7d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T07:16:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-01T23:04:22.000Z",
+        "ImageId": "ami-0220823977b0c19e0",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0da595c81be4b6eb5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T23:04:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-09-21T08:13:46.000Z",
+        "ImageId": "ami-0221af63402a4cf57",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d501877a35a01c66",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T08:13:46.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T01:10:24.000Z",
+        "ImageId": "ami-022263e0377cd4e67",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b8322bb9cf984cf1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:10:24.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-07T11:50:54.000Z",
+        "ImageId": "ami-0229a5cd9ec89e82e",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02b76aea32bdbc338",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T11:50:54.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T20:16:47.000Z",
+        "ImageId": "ami-0238d5f7b9ef3eefa",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-028996095592c0404",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T20:16:47.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T20:40:04.000Z",
+        "ImageId": "ami-0241a60933c527bc6",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04894555435498907",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-24T20:40:04.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T16:05:52.000Z",
+        "ImageId": "ami-025922f59d1a00afb",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d932d913aa31ed20",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T16:05:52.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T15:25:34.000Z",
+        "ImageId": "ami-0263d5e5bfb0834b4",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d9eecc9f23dc5d18",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T15:25:34.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-26T17:33:20.000Z",
+        "ImageId": "ami-026f9cf2ebf2e89f5",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230623-arm64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-071231c4892db266b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230623-arm64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T17:33:20.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-13T18:29:13.000Z",
+        "ImageId": "ami-027f8c635381b2654",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f2593ad8c5da1338",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T18:29:13.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-05-10T11:48:08.000Z",
+        "ImageId": "ami-0286e56418e02dc59",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230503-arm64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0da1737be8ab2e4b8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230503-arm64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T11:48:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T16:49:57.000Z",
+        "ImageId": "ami-0290ec7dd7f41cf84",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07a6860decdf1b2b9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T16:49:57.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-22T08:00:01.000Z",
+        "ImageId": "ami-0297adfab4a8f91b4",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fe8ddc078f28f795",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-22T08:00:01.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-30T19:26:19.000Z",
+        "ImageId": "ami-02af58c6f8ccda5aa",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08389a7942f0b0204",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-30T19:26:19.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-06T17:52:22.000Z",
+        "ImageId": "ami-02b610226559a548b",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bb1aacbddc21114c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-06T17:52:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-25T07:17:24.000Z",
+        "ImageId": "ami-02b7d3099dc3e64fd",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240117-arm64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02d016a361b330d62",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240117-arm64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T07:17:24.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-01T23:24:58.000Z",
+        "ImageId": "ami-02d7c6dd92421ea99",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e9897749516fb245",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T23:24:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-22T15:51:55.000Z",
+        "ImageId": "ami-02ddcb7203d944f1f",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM_BETA-20230228-x86_64-22-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08ddfdcd7372b3833",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM_BETA-20230228-x86_64-22-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-22T15:51:55.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-11T20:15:08.000Z",
+        "ImageId": "ami-02ef4053c0dcd88d2",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM_BETA-20240411-x86_64-30-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fac6970a5e8be7f2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM_BETA-20240411-x86_64-30-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-11T20:15:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-28T10:15:52.000Z",
+        "ImageId": "ami-02f28c7684cc5bcd6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-086a328d3919bf500",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-28T10:15:52.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-06T19:25:38.000Z",
+        "ImageId": "ami-0316172d0f1f3c5e9",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2ffde7dbaaa266e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-06T19:25:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-28T21:15:36.000Z",
+        "ImageId": "ami-031f3c957493e8d8b",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-091ed57304e41cc68",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T21:15:36.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-02-14T23:17:13.000Z",
+        "ImageId": "ami-033799a906e5491f0",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04daf9bc1a240c386",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-02-14T23:17:13.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T15:31:04.000Z",
+        "ImageId": "ami-035f582573bf5877e",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fc120dc3a4157dab",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T15:31:04.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T10:24:51.000Z",
+        "ImageId": "ami-036dd77000cc7df51",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-011a94216c281658b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T10:24:51.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-22T08:02:14.000Z",
+        "ImageId": "ami-0381b98d592d3ac93",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ecacafab7279f252",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20231114-x86_64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-22T08:02:14.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T20:18:17.000Z",
+        "ImageId": "ami-038de83fa0b7c82b1",
+        "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01cf6cf290c14cef1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T20:18:17.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T18:28:19.000Z",
+        "ImageId": "ami-03be6c664f7df2375",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-046c134fd6843d6fe",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T18:28:19.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T18:22:48.000Z",
+        "ImageId": "ami-03e598f48209620e0",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f14acc09d089f172",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T18:22:48.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-06T18:10:58.000Z",
+        "ImageId": "ami-03fe5930b11f9c0ee",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-006e91cbec999a153",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-06T18:10:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-05T17:20:19.000Z",
+        "ImageId": "ami-042454ac99ed39889",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08d8674c5e847e0db",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T17:20:19.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-12-07T21:28:52.000Z",
+        "ImageId": "ami-0425925aa66829f03",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231207-arm64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-026ff351140d96ff4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231207-arm64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-12-07T21:28:52.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T12:25:53.000Z",
+        "ImageId": "ami-042ed7f512738e094",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0656c29df32a52cc9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T12:25:53.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-04T18:03:24.000Z",
+        "ImageId": "ami-04353d30497a41f7d",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04f7de7ce9bec8ad5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-04T18:03:24.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T11:12:25.000Z",
+        "ImageId": "ami-0484dcd0dc70d918a",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cd5db883ab037d53",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T11:12:25.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-17T00:10:01.000Z",
+        "ImageId": "ami-04b1e023b2d92e995",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00812336941f27795",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-17T00:10:01.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-05-03T19:32:58.000Z",
+        "ImageId": "ami-04b624659d0c1637a",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09b7bdc16d6a2ca03",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T19:32:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T16:33:55.000Z",
+        "ImageId": "ami-04be3d35b838f80cb",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e12972bb7e24662e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T16:33:55.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-01T22:44:41.000Z",
+        "ImageId": "ami-04c407b5032916530",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0eaebbeafda115ea7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T22:44:41.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-15T16:03:19.000Z",
+        "ImageId": "ami-04cc8ca6ad7ad1d38",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bfea9f9e99ff8c9c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T16:03:19.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-31T18:05:38.000Z",
+        "ImageId": "ami-04d69e154b3c66ee5",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0290e8d6510609845",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T18:05:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T16:10:53.000Z",
+        "ImageId": "ami-04ec8e5b6293e8b72",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09d5a76c607ce65aa",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-24T16:10:53.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-16T10:20:06.000Z",
+        "ImageId": "ami-04f91ed2f120d8dbb",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM-20240514-arm64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c99ced049a62268a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM-20240514-arm64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-16T10:20:06.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-05T06:06:11.000Z",
+        "ImageId": "ami-052ee1769d780fb88",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240229-arm64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d7e8825033494d44",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240229-arm64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T06:06:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-13T18:23:48.000Z",
+        "ImageId": "ami-05447ad703233ace6",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ca0e1fcff2dedd60",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T18:23:48.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T11:54:26.000Z",
+        "ImageId": "ami-0545798a621cfd02b",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08160688b06d3842b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T11:54:26.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-10-03T23:55:47.000Z",
+        "ImageId": "ami-0556199845368e99d",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231003-arm64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0706e735c5ec56f7e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231003-arm64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-03T23:55:47.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-11T06:47:40.000Z",
+        "ImageId": "ami-057bbe473671c1eb7",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04ad83da342568ca2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T06:47:40.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-24T19:17:24.000Z",
+        "ImageId": "ami-0594f7a0514628415",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240117-arm64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ab0077f43a9d7b00",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240117-arm64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T19:17:24.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-06T22:38:50.000Z",
+        "ImageId": "ami-05b0c29becdaf7af9",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bbb5bdfe79b05731",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T22:38:50.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-18T18:20:19.000Z",
+        "ImageId": "ami-05be1ba4b049455e0",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230712-arm64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-052a3d1c353e87e0b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230712-arm64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T18:20:19.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T01:58:46.000Z",
+        "ImageId": "ami-05f8f8ac71b41b1a0",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ed4e16dc834f6e8c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-05T01:58:46.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T02:29:23.000Z",
+        "ImageId": "ami-0611d6a27c7571d0d",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a7e4285ee21b581c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T02:29:23.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-12-07T21:32:27.000Z",
+        "ImageId": "ami-06227cd72bb488950",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ec91932cebd040be",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-12-07T21:32:27.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-02T08:05:22.000Z",
+        "ImageId": "ami-062b8ad0279a58150",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0214b1955e99d0522",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-02T08:05:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T12:13:51.000Z",
+        "ImageId": "ami-0640f9f9f599568b6",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-079363a0183c5824c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230418-x86_64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T12:13:51.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-18T19:57:35.000Z",
+        "ImageId": "ami-065222783b3fe5dc0",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-091071dc028b9ea3a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T19:57:35.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-06T22:48:51.000Z",
+        "ImageId": "ami-06778dfc839154edd",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0771f38b7defa7878",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T22:48:51.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T19:44:06.000Z",
+        "ImageId": "ami-068a2369119a94647",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02861333a367bffbf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T19:44:06.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T19:35:45.000Z",
+        "ImageId": "ami-06a43df7e9a97d129",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f6cf9e558ab27de4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T19:35:45.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-27T23:13:17.000Z",
+        "ImageId": "ami-06b09c2d6e8573eca",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-020a47e5fb8c970fc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-27T23:13:17.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-24T14:08:23.000Z",
+        "ImageId": "ami-06bc9712bc96ccda2",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM_BETA-20230306-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00730f5afaf1e19b0",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM_BETA-20230306-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-24T14:08:23.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-04T10:05:10.000Z",
+        "ImageId": "ami-06d4ec6426a79c849",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240229-arm64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02266dc10c4a251dd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240229-arm64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T10:05:10.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-31T01:00:12.000Z",
+        "ImageId": "ami-06e81f5ac03d6a7e0",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-023097d6d3a9a6edf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-31T01:00:12.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-03T23:56:03.000Z",
+        "ImageId": "ami-06fa918c1c85ea7b3",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-083ace85a236595f7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-03T23:56:03.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-21T10:23:34.000Z",
+        "ImageId": "ami-070916ffa2eea6f4c",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230418-arm64-6-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ad5ca94d06375cc1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230418-arm64-6-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T10:23:34.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T11:57:32.000Z",
+        "ImageId": "ami-0724d9262957ec59f",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0de137b00521592b7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T11:57:32.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-27T14:06:55.000Z",
+        "ImageId": "ami-07997a71d6556a243",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04cf58d5232238aa9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-27T14:06:55.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-22T14:27:48.000Z",
+        "ImageId": "ami-079cf478b150236d7",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM_BETA-20230914-arm64-63-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bf04117a36089172",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM_BETA-20230914-arm64-63-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-22T14:27:48.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T14:17:02.000Z",
+        "ImageId": "ami-07a0feff68556e092",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0057205baffaf68ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T14:17:02.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T10:05:27.000Z",
+        "ImageId": "ami-07d2c044ed099e72f",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0dcb83fa1a9ac2696",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T10:05:27.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T10:05:32.000Z",
+        "ImageId": "ami-07e4c5fb3a8c58b86",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b336f53525118cfd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240229-x86_64-33-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T10:05:32.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-24T01:07:05.000Z",
+        "ImageId": "ami-07e87da89bf75bbc2",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0053b76484fc6b9a3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:07:05.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T02:04:42.000Z",
+        "ImageId": "ami-07eb853e27881a9e5",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07764316cea010799",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-05T02:04:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-04T17:52:25.000Z",
+        "ImageId": "ami-0805d0bc6157f4bed",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240103-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03f672d86776d9476",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240103-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-04T17:52:25.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-06T18:10:52.000Z",
+        "ImageId": "ami-080f42ab83dbd0c83",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04ff41d2af5314643",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-06T18:10:52.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-10T11:25:48.000Z",
+        "ImageId": "ami-08178c63ab93b055a",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20231101-arm64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02aa723cbe4434930",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20231101-arm64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-10T11:25:48.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-14T00:31:20.000Z",
+        "ImageId": "ami-08231fa88fd6ad25c",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01fd02a207d6f7108",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T00:31:20.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-10-11T17:02:08.000Z",
+        "ImageId": "ami-082b23d451918cc3a",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fa0335059967457a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T17:02:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T07:29:18.000Z",
+        "ImageId": "ami-083667c3c3ddc16af",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-070cb82ef41882ece",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T07:29:18.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-02T08:05:16.000Z",
+        "ImageId": "ami-0841d7066819493e7",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07bb58bc03fa52fde",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230301-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-02T08:05:16.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-19T20:35:13.000Z",
+        "ImageId": "ami-0854a8aa6609975ab",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01c9c36e0e18ac25e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-19T20:35:13.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-09T20:29:42.000Z",
+        "ImageId": "ami-0869bb7c755470410",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-049b8157e62414574",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T20:29:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T16:11:33.000Z",
+        "ImageId": "ami-08b733aabfb3d9b72",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-015ced92d44a1550e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-24T16:11:33.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T21:44:42.000Z",
+        "ImageId": "ami-08c5392fe817cf005",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-017d16e5442d706a9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T21:44:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-05T17:30:57.000Z",
+        "ImageId": "ami-08e05e87c9d957572",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03f027e4a5ac067a7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T17:30:57.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-20T19:17:22.000Z",
+        "ImageId": "ami-08f6f9ac8b2d6d48b",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e04f1e4174f25c6c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T19:17:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-03T20:37:30.000Z",
+        "ImageId": "ami-08f9962d25b40516a",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0529790dda36b1ef3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T20:37:30.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-27T23:16:10.000Z",
+        "ImageId": "ami-090149512ed2d2d99",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08a46b59b42c3c524",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-27T23:16:10.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-14T12:46:33.000Z",
+        "ImageId": "ami-091874eb1aaf0e167",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02fdbf8682d370246",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-14T12:46:33.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T18:12:15.000Z",
+        "ImageId": "ami-0932d1cf8d2dd2f88",
+        "ImageLocation": "amazon/RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08bf76618a43a17d4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T18:12:15.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-28T14:32:16.000Z",
+        "ImageId": "ami-094c8762457290b7f",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0768bdc6aaaaa3368",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T14:32:16.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-09-21T14:23:26.000Z",
+        "ImageId": "ami-0950db1e1348f355f",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06296371b26d356ba",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T14:23:26.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T19:17:25.000Z",
+        "ImageId": "ami-0951cee7b6ae09843",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b1017e318a709886",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-24T19:17:25.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-12T16:54:38.000Z",
+        "ImageId": "ami-09a428a3d3dca48a2",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM_BETA-20240412-x86_64-55-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0956029fe97075123",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM_BETA-20240412-x86_64-55-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-12T16:54:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-28T21:59:42.000Z",
+        "ImageId": "ami-09a7d1c730e46035f",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04caca4fac995f897",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240521-x86_64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-28T21:59:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-11T18:33:46.000Z",
+        "ImageId": "ami-09a8e4c9f125155dd",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0653e84a6c24b358e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T18:33:46.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-15T16:03:42.000Z",
+        "ImageId": "ami-09f4c8590256e496f",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0321ca3cc55218cf2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-15T16:03:42.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-02-14T23:20:08.000Z",
+        "ImageId": "ami-0a09e7f5dcedd437f",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00943851e4656bb06",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-02-14T23:20:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T01:46:20.000Z",
+        "ImageId": "ami-0a0ed0796c695317a",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-00d803a25d24305db",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T01:46:20.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T18:45:37.000Z",
+        "ImageId": "ami-0a5e1b2d6363a6a60",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04a57aa92915cdd7a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T18:45:37.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-20T17:15:40.000Z",
+        "ImageId": "ami-0a63f7ffe5d923003",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05f1c0e7dcaec24b3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20230215-x86_64-13-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-20T17:15:40.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-12-07T21:29:07.000Z",
+        "ImageId": "ami-0a86fe673b78e7240",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e7fa8e8c7721e43f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-12-07T21:29:07.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T10:20:07.000Z",
+        "ImageId": "ami-0a96460b8523b28a6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05fcf37e763960411",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T10:20:07.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-17T00:11:20.000Z",
+        "ImageId": "ami-0aab23056c9e11588",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b9a5e4143a5e595c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-17T00:11:20.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-02-23T12:27:27.000Z",
+        "ImageId": "ami-0ab8c6e9787d502f5",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230222-arm64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f6a96d7e6de6931d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230222-arm64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T12:27:27.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-29T06:56:17.000Z",
+        "ImageId": "ami-0ad42868ec791c41d",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240521-arm64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-058669f2bdab777c5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240521-arm64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T06:56:17.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-04T00:44:51.000Z",
+        "ImageId": "ami-0b062d4a065d7356c",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0aed19af9911d4a99",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20231003-x86_64-16-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-04T00:44:51.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-02T19:24:50.000Z",
+        "ImageId": "ami-0b09bdd019f712561",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03dcc9587ef72239e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-02T19:24:50.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-30T22:25:32.000Z",
+        "ImageId": "ami-0b1e55d7dadb6855c",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230127-arm64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c8be312eee7129f9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230127-arm64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T22:25:32.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T04:33:18.000Z",
+        "ImageId": "ami-0b3bc117e22e47dd9",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-022e8b0d8988efaef",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T04:33:18.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T18:28:38.000Z",
+        "ImageId": "ami-0b61e0310206fbb06",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0396c5c96e51db84e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-09T18:28:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-31T17:15:28.000Z",
+        "ImageId": "ami-0b69f3ff511f9d0f6",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-042a1ff6fde0be5ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T17:15:28.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-25T08:02:08.000Z",
+        "ImageId": "ami-0b7b76b27d7d551a0",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a49b9545c6b248fd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-25T08:02:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T05:28:39.000Z",
+        "ImageId": "ami-0b825f197401ce46e",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a5229b113bab0d64",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T05:28:39.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-30T23:43:47.000Z",
+        "ImageId": "ami-0b8a241184ac68d07",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230125-arm64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02bfeed591a504a89",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230125-arm64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T23:43:47.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-11T07:09:28.000Z",
+        "ImageId": "ami-0b8e6a4971047b991",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-041251205297798fc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T07:09:28.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T16:54:32.000Z",
+        "ImageId": "ami-0b9cac9c8cecbf1a1",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05fd4c1d8586b3275",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T16:54:32.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-07T12:33:43.000Z",
+        "ImageId": "ami-0bb1f57f0e045461b",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d7d4ae6a82f6122d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T12:33:43.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-04T17:57:44.000Z",
+        "ImageId": "ami-0be03c7208ed41128",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0810a8b7248d60f2f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240103-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-04T17:57:44.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-10T12:01:23.000Z",
+        "ImageId": "ami-0be6a2b1691bc87ac",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06efd6a346458a721",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T12:01:23.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T01:58:00.000Z",
+        "ImageId": "ami-0c2c58e09f01d5435",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07427cb03e9c47123",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T01:58:00.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-11T17:58:39.000Z",
+        "ImageId": "ami-0c30c541e2c302eeb",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-076bf6414815175d2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-11T17:58:39.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-09T22:25:10.000Z",
+        "ImageId": "ami-0c3b13d866cfc435e",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230307-arm64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e23afaddcad5471e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230307-arm64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T22:25:10.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-31T18:06:05.000Z",
+        "ImageId": "ami-0c3d884fcbdfbe118",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0674a8cdd14a9a4b1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T18:06:05.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-14T00:31:15.000Z",
+        "ImageId": "ami-0c5380960dac0cf50",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06bb33e3a5cadeb15",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230313-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T00:31:15.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-16T10:22:07.000Z",
+        "ImageId": "ami-0c71c6fad1165c9fc",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0887ca7124c3fa6cc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-05-16T10:22:07.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T18:46:38.000Z",
+        "ImageId": "ami-0c774d98eb80e18fd",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c64bac8cd61dd037",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-09T18:46:38.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-15T17:09:04.000Z",
+        "ImageId": "ami-0c8a747da0cc09f39",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07d7d40211c239e9c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T17:09:04.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-14T13:40:08.000Z",
+        "ImageId": "ami-0c8ce8ff811b344c5",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0538cc406fb9963e6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-14T13:40:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T20:17:14.000Z",
+        "ImageId": "ami-0c95ffb2dfc3db7ab",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ab6d33d9be9f5d8b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T20:17:14.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T16:33:21.000Z",
+        "ImageId": "ami-0ca247cbc84b22b43",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bbc315864ef387af",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T16:33:21.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-06T22:39:05.000Z",
+        "ImageId": "ami-0cb26241f9386c405",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08488075ed6c12e0c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T22:39:05.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-08-07T11:47:43.000Z",
+        "ImageId": "ami-0cf45a56788d14e10",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230802-arm64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b969fb73c6e5c32c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230802-arm64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T11:47:43.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T20:33:58.000Z",
+        "ImageId": "ami-0d113ed541942504a",
+        "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-078856ca7e2135a91",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T20:33:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-11T17:02:22.000Z",
+        "ImageId": "ami-0d19c1106e41de31c",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09adddd874e8ea9ed",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T17:02:22.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T11:25:11.000Z",
+        "ImageId": "ami-0d7c0d6260a7b52a6",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-077ec04215d389246",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T11:25:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-21T14:17:09.000Z",
+        "ImageId": "ami-0d7face6a01c43ac3",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230419-arm64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09916c5c3f77b2ab8",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230419-arm64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T14:17:09.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T01:50:11.000Z",
+        "ImageId": "ami-0d82174fec659b4fe",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0300c72fa1da35ca6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T01:50:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-05T17:20:03.000Z",
+        "ImageId": "ami-0d8c8e5cad10df1de",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ba631b3f375f681d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T17:20:03.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-16T10:19:39.000Z",
+        "ImageId": "ami-0d9563996fdd5dc24",
+        "ImageLocation": "amazon/RHEL_HA-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d0f465197953229e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-05-16T10:19:39.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-27T23:13:15.000Z",
+        "ImageId": "ami-0dc5c695c12eca4eb",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20231127-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02f6b9a5fc499855a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20231127-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-27T23:13:15.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-31T17:58:05.000Z",
+        "ImageId": "ami-0de033e33e6b64002",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c5014514998de510",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-31T17:58:05.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-06T07:27:24.000Z",
+        "ImageId": "ami-0e0329f2853c44f34",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0335583687a143696",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T07:27:24.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-24T04:32:08.000Z",
+        "ImageId": "ami-0e1f5f04a52a2b7b2",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240419-arm64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e7c8f07fb35a0050",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240419-arm64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T04:32:08.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-30T02:56:48.000Z",
+        "ImageId": "ami-0e21fe20ea434fecf",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2bf70be6e06dd0e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-30T02:56:48.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-22T15:54:59.000Z",
+        "ImageId": "ami-0e3d8d92b779fcb7d",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05b15e3deaa26c4de",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-22T15:54:59.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-14T13:40:05.000Z",
+        "ImageId": "ami-0e413ded8bfc540c6",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0401119e42bd0db9d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20230913-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-14T13:40:05.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-22T15:56:33.000Z",
+        "ImageId": "ami-0e5268dbabdaedbc7",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM_BETA-20230912-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e5e7e7e38759d060",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM_BETA-20230912-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-09-22T15:56:33.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-02-15T00:23:44.000Z",
+        "ImageId": "ami-0e559247020d61e9e",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-035648f13cf788b8f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-02-15T00:23:44.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-15T17:43:02.000Z",
+        "ImageId": "ami-0e5eebe4b746e03c5",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f0a57e9137d13a12",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T17:43:02.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-24T14:07:11.000Z",
+        "ImageId": "ami-0e7c1794639679fef",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM_BETA-20230306-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0000459d451cc685d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM_BETA-20230306-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-24T14:07:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T14:27:53.000Z",
+        "ImageId": "ami-0e93b17eb51462d49",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0179bc199ce5914e6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T14:27:53.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-05T01:12:54.000Z",
+        "ImageId": "ami-0e99096959a59cf93",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01e58013b33a8070e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T01:12:54.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-22T07:02:58.000Z",
+        "ImageId": "ami-0e9fbd17682ec221d",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231114-arm64-59-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06d58a5acda9109e4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231114-arm64-59-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-22T07:02:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T06:08:15.000Z",
+        "ImageId": "ami-0edc1d02f63215452",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0130f791ae75ae1ec",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T06:08:15.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T06:08:34.000Z",
+        "ImageId": "ami-0ee6153dd5b6810ee",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02d68a89d5e1c3d74",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T06:08:34.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T11:26:33.000Z",
+        "ImageId": "ami-0efc6736cea99f4bc",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07266e10ba797d9f7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T11:26:33.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-10T11:50:01.000Z",
+        "ImageId": "ami-0f040af5840a338ed",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05de26ee695e885e5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-10T11:50:01.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-02T08:27:43.000Z",
+        "ImageId": "ami-0f236fa8de4c992a4",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230301-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-099e220355f6dd174",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230301-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-02T08:27:43.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-30T03:28:50.000Z",
+        "ImageId": "ami-0f41a24d79b25ef06",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04f4db830f57d4d42",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-30T03:28:50.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-30T19:26:36.000Z",
+        "ImageId": "ami-0f6e76c1ceaed5657",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fc34b86b5ca6daab",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240123-x86_64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-30T19:26:36.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-09T22:25:41.000Z",
+        "ImageId": "ami-0f89fdf86599e5b11",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0990d824c17be413f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T22:25:41.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-06T07:03:40.000Z",
+        "ImageId": "ami-0f8d2bb356c51b1d1",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06eba065caca7adac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T07:03:40.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-19T20:14:10.000Z",
+        "ImageId": "ami-0fa8cedc1a3f59887",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230118-arm64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b649558cbc8411f2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230118-arm64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-19T20:14:10.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-26T17:29:58.000Z",
+        "ImageId": "ami-0fc4931f101d144f9",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b2a4aca38cd44f79",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-26T17:29:58.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-14T00:31:10.000Z",
+        "ImageId": "ami-0ff46522157342dd0",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230313-arm64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-050ac4ad33124b9c5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230313-arm64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T00:31:10.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-05T01:16:11.000Z",
+        "ImageId": "ami-0ff538af227cceb1d",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-090298ce4159249ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-05T01:16:11.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T10:08:25.000Z",
+        "ImageId": "ami-0ff893cbb0f72f2ae",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0715165f8b9cc672b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T10:08:25.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-30T02:59:15.000Z",
+        "ImageId": "ami-0fff4c6f5101804a6",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01aeb7b53f2b9e2a3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-30T02:59:15.000Z",
+        "Region": "ap-east-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T09:05:39.000Z",
+        "ImageId": "ami-0014871499315f25a",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01bd263caa295f860",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-24T09:05:39.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T10:57:46.000Z",
+        "ImageId": "ami-0055e0b5158277c74",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-021692820796511d7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T10:57:46.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-13T19:49:40.000Z",
+        "ImageId": "ami-0061e2b01ccc144d8",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a985f6bcd6ad556f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230411-arm64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T19:49:40.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-21T12:27:18.000Z",
+        "ImageId": "ami-006f28e2c3645caa4",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ae62f7cf33509558",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230419-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-21T12:27:18.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-12-07T20:02:25.000Z",
+        "ImageId": "ami-0084578a23199cc77",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-045aede91ab8b2efd",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231207-x86_64-20-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-12-07T20:02:25.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T12:56:25.000Z",
+        "ImageId": "ami-008e7567412b36c6d",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0cf786c1d09bf8abf",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240521-x86_64-93-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T12:56:25.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T02:16:53.000Z",
+        "ImageId": "ami-00985a623830f94b8",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-037ca9bf61d3386fb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20231115-x86_64-15-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T02:16:53.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-10T19:49:27.000Z",
+        "ImageId": "ami-00a4dc27c7b47599d",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-053658b4d53112b3b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-10T19:49:27.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-31T16:04:13.000Z",
+        "ImageId": "ami-00ab8352c58715d37",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-086c8dd923bfb92c2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM-20230330-arm64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T16:04:13.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T17:52:25.000Z",
+        "ImageId": "ami-00e8be75a9ac10224",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0297007a1039a30b1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T17:52:25.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-28T06:23:24.000Z",
+        "ImageId": "ami-012a9ac1fc1cd76ae",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03df3984ded1667b2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20231127-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-28T06:23:24.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T18:27:00.000Z",
+        "ImageId": "ami-013238b3531b8fdb0",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09f34cf75fd445745",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T18:27:00.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-07T07:14:39.000Z",
+        "ImageId": "ami-0149aa39b7b5d9e05",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c84e10267581b0f2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-07T07:14:39.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-06T19:24:39.000Z",
+        "ImageId": "ami-014efd61014ec96e9",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-026970f08be7b4bf9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-06T19:24:39.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T21:53:58.000Z",
+        "ImageId": "ami-0162125e69182350b",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09db9eb9934d03965",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240229-x86_64-27-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-04T21:53:58.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-02-15T05:04:19.000Z",
+        "ImageId": "ami-016b5630db05dc253",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d27ec20315108345",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-arm64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-02-15T05:04:19.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T03:14:28.000Z",
+        "ImageId": "ami-017455efa07ec8ff6",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bace1b3d37a2b54f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240419-x86_64-63-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-24T03:14:28.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-30T03:44:46.000Z",
+        "ImageId": "ami-0178015d622849f25",
+        "ImageLocation": "amazon/RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08077fe82bea8696f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.8.0_HVM-20240424-x86_64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-30T03:44:46.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-24T08:07:26.000Z",
+        "ImageId": "ami-017f76ff72c3d0cdc",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ae114e03b7aa5aba",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20240117-arm64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T08:07:26.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-28T07:35:14.000Z",
+        "ImageId": "ami-01a6a8fbc49daea9c",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0642d18065e6f8029",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-arm64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-28T07:35:14.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-07T16:46:21.000Z",
+        "ImageId": "ami-01b760eab729a9f4c",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-05c35c21cd166e41f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230802-x86_64-64-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-07T16:46:21.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-03T17:26:53.000Z",
+        "ImageId": "ami-01bb8868a249be5ca",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01190fa27ebf59b9f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T17:26:53.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-14T00:57:16.000Z",
+        "ImageId": "ami-01c18b1f46deb3457",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230313-arm64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0fc33ae84a3ebb437",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230313-arm64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-14T00:57:16.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-15T02:22:16.000Z",
+        "ImageId": "ami-01c74a88f35c5c1b4",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f60a7ff460637f7f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240312-x86_64-84-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-15T02:22:16.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T12:18:37.000Z",
+        "ImageId": "ami-01d4045ae1f932d65",
+        "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-01e736ddc5fb3c05e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T12:18:37.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-29T02:15:47.000Z",
+        "ImageId": "ami-01d8f589f3df9b2df",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-005de6d66989cea59",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T02:15:47.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-06T07:45:51.000Z",
+        "ImageId": "ami-01dca0aeb230ee8eb",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06e5547c53ba4bbbc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-x86_64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T07:45:51.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-15T03:43:54.000Z",
+        "ImageId": "ami-0201712bbeab07835",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c7837ef3119246e7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230913-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-15T03:43:54.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T22:47:26.000Z",
+        "ImageId": "ami-0236c542da78c5799",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a9afcde84103a1be",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240229-x86_64-19-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T22:47:26.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-11-09T18:55:56.000Z",
+        "ImageId": "ami-0240ede43eb37c894",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-075eb64dc1aebc427",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T18:55:56.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-02-23T12:48:55.000Z",
+        "ImageId": "ami-026b530b0d6368eea",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230222-arm64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-037d0fdc084e8bdc4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230222-arm64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T12:48:55.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-06-10T19:49:14.000Z",
+        "ImageId": "ami-028316c530e8f9c54",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0951b83377e993767",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240605-arm64-32-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-06-10T19:49:14.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-01T23:35:50.000Z",
+        "ImageId": "ami-0294b0eca438d33b3",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-014b2654e318f8814",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-01T23:35:50.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-05T21:20:21.000Z",
+        "ImageId": "ami-029ecabe07b41311a",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e2cf223b7342f97c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-x86_64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T21:20:21.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T02:38:01.000Z",
+        "ImageId": "ami-02c6fff3d076b5944",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0b496d63f514cf6fc",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20240117-x86_64-2-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T02:38:01.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T20:19:32.000Z",
+        "ImageId": "ami-02db0957bdbdb33bd",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07378cedf9beef14e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T20:19:32.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T08:07:47.000Z",
+        "ImageId": "ami-02e476d3b53f3be9b",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06c6924faac815def",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20240117-x86_64-52-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T08:07:47.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-10-11T10:41:04.000Z",
+        "ImageId": "ami-0300c29883fc847bf",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0595b72dd81863f6b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-x86_64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T10:41:04.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-02-15T05:07:13.000Z",
+        "ImageId": "ami-033050a99b0cf28b4",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-011c0ef1cdd9d36cb",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240213-x86_64-3-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-02-15T05:07:13.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-05-29T15:51:40.000Z",
+        "ImageId": "ami-033fd2277e242435e",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07238aba28017202c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20240521-arm64-58-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T15:51:40.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-04-13T19:57:55.000Z",
+        "ImageId": "ami-034669bb30b8e284c",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e6ce847005dc2719",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230411-x86_64-60-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-13T19:57:55.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T18:37:37.000Z",
+        "ImageId": "ami-0347f46bc0ff51259",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04d3f896c7a45f7e3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230823-x86_64-20-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T18:37:37.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-31T17:49:56.000Z",
+        "ImageId": "ami-037363e0794e85af0",
+        "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0342716cae0e93543",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.7.0_HVM-20230330-x86_64-56-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-31T17:49:56.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-07T17:44:20.000Z",
+        "ImageId": "ami-0379e4102a513b6d7",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-044543ecb60db3fc2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-07T17:44:20.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T19:08:17.000Z",
+        "ImageId": "ami-0388227e72d10fa9a",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0db3986977e72ad8e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20231101-x86_64-5-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-09T19:08:17.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-06T18:40:31.000Z",
+        "ImageId": "ami-039215154b2764b99",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0947ca3aed5236a8e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-arm64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T18:40:31.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-05-03T17:34:49.000Z",
+        "ImageId": "ami-03f6f03d246664add",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07ff701928da28cb1",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T17:34:49.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2022-11-03T18:25:26.000Z",
+        "ImageId": "ami-04103d6bd9b2b2d28",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-038fbc75f713157de",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-03T18:25:26.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T23:13:37.000Z",
+        "ImageId": "ami-042890a2c52315d75",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f52588e54ea0622e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T23:13:37.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-16T02:51:04.000Z",
+        "ImageId": "ami-042e19e1a8077c273",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0a2491baa28318584",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-arm64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-16T02:51:04.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-16T12:52:34.000Z",
+        "ImageId": "ami-044362faacfe8a883",
+        "ImageLocation": "amazon/RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e31a81f12d157d89",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.10.0_HVM-20240514-x86_64-76-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-05-16T12:52:34.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T19:42:20.000Z",
+        "ImageId": "ami-0469920c86c75d129",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0964c1d7d33448438",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T19:42:20.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-05-03T17:56:07.000Z",
+        "ImageId": "ami-0477d3aed9e98876c",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-06e1fe5412e0c5121",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-05-03T17:56:07.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T11:20:47.000Z",
+        "ImageId": "ami-047b52d377d7cfc4f",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ecb763837abd9f8f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240117-x86_64-13-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-24T11:20:47.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-28T13:11:12.000Z",
+        "ImageId": "ami-04829c4e2dbb67968",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0740c9a8397245b43",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-arm64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-28T13:11:12.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T22:07:38.000Z",
+        "ImageId": "ami-0485861a3a7107eac",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0ea24e63b77de66b9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230712-x86_64-7-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T22:07:38.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-02T19:19:13.000Z",
+        "ImageId": "ami-048a5dc0ebac37105",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0d02a12e017fb66c3",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-02T19:19:13.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-07-18T19:11:43.000Z",
+        "ImageId": "ami-048fef81d151bd0f6",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-042fb505e3ffb53b4",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-arm64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T19:11:43.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T20:14:52.000Z",
+        "ImageId": "ami-049d7fdfe6a48ce12",
+        "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-04752277038b81568",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T20:14:52.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T21:04:23.000Z",
+        "ImageId": "ami-04ceba7b59618a6c5",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0930061cacefa3167",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230127-x86_64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T21:04:23.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-06-07T07:17:52.000Z",
+        "ImageId": "ami-04d3ba818c434b384",
+        "ImageLocation": "amazon/RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-03af5d2bfb3a3da34",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-06-07T07:17:52.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-27T14:04:53.000Z",
+        "ImageId": "ami-04e020d9da1e7bcef",
+        "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0dff1ea11c7d3184c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-27T14:04:53.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-06T18:39:15.000Z",
+        "ImageId": "ami-04fdeff70b7359022",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-093096f4ac427d275",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230905-x86_64-38-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-06T18:39:15.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-10-27T20:41:45.000Z",
+        "ImageId": "ami-05016d58118cb4881",
+        "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0e1cf61d54b581695",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-10-27T20:41:45.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-02-23T12:34:21.000Z",
+        "ImageId": "ami-0539a3bd22eb244ee",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f2c479a6995c4d63",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230222-x86_64-39-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-02-23T12:34:21.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T12:32:00.000Z",
+        "ImageId": "ami-053b21ed5635f0b74",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0807548df83c30f7f",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T12:32:00.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-16T20:17:49.000Z",
+        "ImageId": "ami-053e45b99ff65010d",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-043f8fff8fd995230",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20231115-x86_64-23-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-16T20:17:49.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-18T19:12:08.000Z",
+        "ImageId": "ami-0574c139b2c13c029",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0bdfa926e10291d25",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230712-x86_64-43-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-18T19:12:08.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-09-23T00:09:37.000Z",
+        "ImageId": "ami-05a61428328ec7664",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-066b27406db5b27a2",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM_BETA-20230914-x86_64-63-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-09-23T00:09:37.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-16T02:53:57.000Z",
+        "ImageId": "ami-05c56cdc38437e43e",
+        "ImageLocation": "amazon/RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0c5c71167d22bc619",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.2.0_HVM-20230615-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-16T02:53:57.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-01-30T18:16:46.000Z",
+        "ImageId": "ami-05d8daf630123c0fa",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0664788a178a1131d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240123-arm64-22-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-01-30T18:16:46.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-08-25T18:40:33.000Z",
+        "ImageId": "ami-05df9b7e4bf893c78",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f2d30e259a78f585",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20230822-x86_64-17-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-08-25T18:40:33.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-04-05T21:20:14.000Z",
+        "ImageId": "ami-060f30d3d41a71515",
+        "ImageLocation": "amazon/RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f9d50cd7d2853cb7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.1.0_HVM-20230404-arm64-54-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-04-05T21:20:14.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-06-06T07:43:29.000Z",
+        "ImageId": "ami-061b486e98f014dff",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07f62274719bf1ca7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230531-arm64-4-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-06T07:43:29.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-30T17:01:06.000Z",
+        "ImageId": "ami-0624ca3d372df386e",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08535488fd995681e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230125-x86_64-35-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T17:01:06.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T13:14:05.000Z",
+        "ImageId": "ami-062921cd4e5cbddc1",
+        "ImageLocation": "amazon/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-073705d71a608da2c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T13:14:05.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-09T20:51:23.000Z",
+        "ImageId": "ami-0638553dcb89371c3",
+        "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07eeb00e8d997822d",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T20:51:23.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-04-30T03:31:31.000Z",
+        "ImageId": "ami-063b109d7a7629d47",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08951466d58fc5b11",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20240424-arm64-53-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-04-30T03:31:31.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-06-27T02:31:34.000Z",
+        "ImageId": "ami-063c13b7924c62541",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02ba302c4a95dc6ba",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-06-27T02:31:34.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-10T12:32:16.000Z",
+        "ImageId": "ami-065c231faeb5da85a",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-061cbeceb73abe2e7",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20231101-x86_64-11-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2025-11-10T12:32:16.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-10-11T10:40:36.000Z",
+        "ImageId": "ami-06982f18d61141803",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07892dda0fd1119ac",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20231009-arm64-59-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-10-11T10:40:36.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-01-19T21:31:38.000Z",
+        "ImageId": "ami-06a0dd9bdeeaccf21",
+        "ImageLocation": "amazon/RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02e374179e28ac2ab",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.6.0_HVM-20230118-x86_64-30-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-19T21:31:38.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-01-24T11:18:15.000Z",
+        "ImageId": "ami-06c651c9e2f524c04",
+        "ImageLocation": "amazon/RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0685230fdf229c3c5",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.3.0_HVM-20240117-x86_64-49-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-01-24T11:18:15.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-04-24T17:32:28.000Z",
+        "ImageId": "ami-06f35fa38748413c0",
+        "ImageLocation": "amazon/RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-07a50f60a241d7b45",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.4.0_HVM-20240423-x86_64-62-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-04-24T17:32:28.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-03-09T22:48:19.000Z",
+        "ImageId": "ami-07351feb1dffeafbe",
+        "ImageLocation": "amazon/RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0642459759d59c0b9",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.4.0_HVM-20230307-x86_64-12-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-09T22:48:19.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-03-22T15:52:22.000Z",
+        "ImageId": "ami-073f5fb674ede2fdf",
+        "ImageLocation": "amazon/RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09dead49779688d2e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.8.0_HVM_BETA-20230228-arm64-22-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-03-22T15:52:22.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T02:16:31.000Z",
+        "ImageId": "ami-07457413856b8f0bf",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-051b835ac41160820",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T02:16:31.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-11-09T18:10:20.000Z",
+        "ImageId": "ami-074de61ca96feeba2",
+        "ImageLocation": "amazon/RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f69aa82114f5a79c",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.1.0_HVM-20231109-x86_64-3-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-11-09T18:10:20.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T14:16:01.000Z",
+        "ImageId": "ami-07596c9a53b5041f3",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-010d5247b45101d20",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T14:16:01.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-04T14:01:57.000Z",
+        "ImageId": "ami-07c0e141cda792282",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-08fddb8fd541aa13b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T14:01:57.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-09-22T18:03:58.000Z",
+        "ImageId": "ami-07ce0c6cae4025f86",
+        "ImageLocation": "amazon/RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0f89d80a0ec47a114",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.3.0_HVM_BETA-20230912-arm64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-09-22T18:03:58.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2023-01-30T22:17:44.000Z",
+        "ImageId": "ami-07d049c90258b7cff",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20230127-arm64-24-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-02be16ad8f5e7bdd6",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20230127-arm64-24-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-01-30T22:17:44.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-03-28T14:22:07.000Z",
+        "ImageId": "ami-07d9d0bf49c9eecec",
+        "ImageLocation": "amazon/RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-0eafbbbe061c7f440",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "BootMode": "uefi-preferred",
+        "DeprecationTime": "2026-03-28T14:22:07.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2023-07-31T17:49:07.000Z",
+        "ImageId": "ami-07ff656680dddfa73",
+        "ImageLocation": "amazon/RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-09ce87106ffa4ea1b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.2.0_HVM-20230726-x86_64-61-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2025-07-31T17:49:07.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-09-21T13:43:55.000Z",
+        "ImageId": "ami-08202063f3664b02c",
+        "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-086b75d3238c6457b",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-09-21T13:43:55.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2024-05-29T02:30:07.000Z",
+        "ImageId": "ami-0829823c93aaa8053",
+        "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+        "UsageOperation": "RunInstances:1010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-038a5ac215282194a",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL_HA-9.0.0_HVM-20240521-x86_64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-05-29T02:30:07.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "x86_64",
+        "CreationDate": "2022-11-02T00:03:20.000Z",
+        "ImageId": "ami-083594d506bfbc152",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-008029afe90feac6e",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp2",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-11-02T00:03:20.000Z",
+        "Region": "ap-northeast-1"
+    },
+    {
+        "Architecture": "arm64",
+        "CreationDate": "2024-03-04T13:19:31.000Z",
+        "ImageId": "ami-083c7347dd5e9947a",
+        "ImageLocation": "amazon/RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "ImageType": "machine",
+        "Public": true,
+        "OwnerId": "309956199498",
+        "PlatformDetails": "Red Hat Enterprise Linux",
+        "UsageOperation": "RunInstances:0010",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": true,
+                    "SnapshotId": "snap-098e1ef440ac05439",
+                    "VolumeSize": 10,
+                    "VolumeType": "gp3",
+                    "Encrypted": false
+                }
+            }
+        ],
+        "Description": "Provided by Red Hat, Inc.",
+        "EnaSupport": true,
+        "Hypervisor": "xen",
+        "ImageOwnerAlias": "amazon",
+        "Name": "RHEL-9.0.0_HVM-20240227-arm64-39-Hourly2-GP3",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2026-03-04T13:19:31.000Z",
+        "Region": "ap-northeast-1"
     }
 ]

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -122,9 +122,7 @@ def test_import_aws_images(db):
 
     crud.import_aws_images(db, images)
 
-    # The test data contains the first 10 results from a recent AWS API call.
-    # curl https://cloudx-json-bucket.s3.amazonaws.com/raw/aws/aws.json |jq ".[0:10]" > tests/data/aws.json
-    assert db.query(AwsImage).count() == 10
+    assert db.query(AwsImage).count() == 500
     assert db.query(AwsImage).first().name == images[0]["Name"]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,42 @@
 """Tests for the main module."""
 
+import json
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from cid.main import app
+from cid import crud
+from cid.database import Base
+from cid.main import app, get_db
 
-# Create a TestClient instance to test the FastAPI app
-# https://fastapi.tiangolo.com/tutorial/testing/
+engine = create_engine(
+    "sqlite:///:memory:", connect_args={"check_same_thread": False}, echo=False
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        Base.metadata.create_all(bind=engine)
+        load_test_data()
+        yield db
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        db.close()
+
+
+def load_test_data():
+    db = TestingSessionLocal()
+    with open("tests/data/aws.json") as fileh:
+        images = json.load(fileh)
+    crud.import_aws_images(db, images)
+
+
+app.dependency_overrides[get_db] = override_get_db
+
 client = TestClient(app)
 
 
@@ -61,3 +90,23 @@ def test_versions(mock_versions):
     response = client.get("/versions")
     assert response.status_code == 200
     assert response.json() == ["8.9.0", "9.2.0", "10.0.0"]
+
+
+def test_all_aws_images():
+    response = client.get("/aws")
+    assert response.status_code == 200
+    assert len(response.json()) == 500
+
+
+def test_single_aws_image():
+    response = client.get("/aws/ami-08a20c15f394e5531")
+    assert response.status_code == 200
+    assert response.json()["name"] == "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3"
+
+
+def test_match_aws_image():
+    response = client.get("/aws/match/ami-08a20c15f394e5531")
+    assert response.status_code == 200
+    assert response.json()["name"] == "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3"
+    assert "ami" in response.json()["matching_images"][0]
+    assert "region" in response.json()["matching_images"][0]


### PR DESCRIPTION
This adds endpoints for getting all AWS images, a specific image, and a list of images that match one that is provided.

I need to get ~ 500 AWS image records to ensure I had a decent amount of images to test the matching part.