### PR TITLE
Replace latest endpoint with aws/latest

### DIFF
--- a/cid/main.py
+++ b/cid/main.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 from time import sleep
-from typing import Any, Dict, Generator
+from typing import Generator, Optional
 
 from fastapi import Depends, FastAPI
 from fastapi.encoders import jsonable_encoder
@@ -32,19 +32,15 @@ def read_root() -> dict:
     return {"Hello": "World"}
 
 
-@app.get("/latest")
-def latest(db: Session = Depends(get_db)) -> Dict[str, Any]:  # noqa: B008
-    return {
-        "latest_aws_image": crud.latest_aws_image(db),
-        "latest_azure_image": crud.latest_azure_image(db),
-        "latest_google_image": crud.latest_google_image(db),
-    }
-
-
 @app.get("/aws")
 def all_aws_images(db: Session = Depends(get_db)) -> list:  # noqa: B008
     result = db.query(AwsImage).order_by(AwsImage.creationDate.desc()).all()
     return list(jsonable_encoder(result))
+
+
+@app.get("/aws/latest")
+def latest_aws_image(db: Session = Depends(get_db), arch: Optional[str] = None) -> dict:  # noqa: B008
+    return crud.latest_aws_image(db, arch)
 
 
 @app.get("/aws/{image_id}")

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -8,44 +8,67 @@ from cid.models import AwsImage, AzureImage, GoogleImage
 
 
 def test_latest_aws_image_no_images(db):
-    result = crud.latest_aws_image(db)
-    assert result == {"error": "No images found", "code": 404}
+    result = crud.latest_aws_image(db, None)
+    assert result == {"error": "No images found for AWS.", "code": 404}
 
 
 def test_latest_aws_image(db):
     # Two images, same region, different versions.
     images = [
         AwsImage(
-            id="ami-a",
-            name="test_image_1",
+            id="ami-1a",
+            name="test_image_1a",
+            arch="x86_64",
             version="1.0",
             date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
             region="us-west-1",
-            imageId="ami-a",
+            imageId="ami-1a",
         ),
         AwsImage(
-            id="ami-b",
-            name="test_image_2",
+            id="ami-1b",
+            name="test_image_1b",
+            arch="x86_64",
             version="2.0",
             date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
             region="us-west-1",
-            imageId="ami-b",
+            imageId="ami-1b",
+        ),
+        AwsImage(
+            id="ami-2a",
+            name="test_image_2a",
+            arch="arm64",
+            version="1.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-2a",
+        ),
+        AwsImage(
+            id="ami-2b",
+            name="test_image_2b",
+            arch="arm64",
+            version="2.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-2b",
         ),
     ]
 
     db.add_all(images)
     db.commit()
 
-    result = crud.latest_aws_image(db)
-    assert result["name"] == "test_image_2"
-    assert result["amis"] == {"us-west-1": "ami-b"}
+    result = crud.latest_aws_image(db, None)
+    assert result["x86_64"]["name"] == "test_image_1b"
+    assert result["x86_64"]["amis"] == {"us-west-1": "ami-1b"}
+    assert result["arm64"]["name"] == "test_image_2b"
+    assert result["arm64"]["amis"] == {"us-west-1": "ami-2b"}
 
     # Add the same version to another region.
     db.add(
         AwsImage(
             id="ami-c",
-            name="test_image_2",
+            name="test_image_2b",
             version="2.0",
+            arch="arm64",
             date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
             region="us-west-2",
             imageId="ami-c",
@@ -53,9 +76,58 @@ def test_latest_aws_image(db):
     )
     db.commit()
 
-    result = crud.latest_aws_image(db)
-    assert result["name"] == "test_image_2"
-    assert result["amis"] == {"us-west-1": "ami-b", "us-west-2": "ami-c"}
+    result = crud.latest_aws_image(db, None)
+    assert result["arm64"]["name"] == "test_image_2b"
+    assert result["arm64"]["amis"] == {"us-west-1": "ami-2b", "us-west-2": "ami-c"}
+
+
+def test_latest_aws_image_query_for_arch(db):
+    images = [
+        AwsImage(
+            id="ami-1a",
+            name="test_image_1a",
+            arch="x86_64",
+            version="1.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-1a",
+        ),
+        AwsImage(
+            id="ami-1b",
+            name="test_image_1b",
+            arch="x86_64",
+            version="2.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-1b",
+        ),
+        AwsImage(
+            id="ami-2a",
+            name="test_image_2a",
+            arch="arm64",
+            version="1.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-2a",
+        ),
+        AwsImage(
+            id="ami-2b",
+            name="test_image_2b",
+            arch="arm64",
+            version="2.0",
+            date=datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
+            region="us-west-1",
+            imageId="ami-2b",
+        ),
+    ]
+
+    db.add_all(images)
+    db.commit()
+
+    result = crud.latest_aws_image(db, "x86_64")
+    assert result["x86_64"]["name"] == "test_image_1b"
+    assert result["x86_64"]["amis"] == {"us-west-1": "ami-1b"}
+    assert "arm64" not in result
 
 
 def test_latest_azure_image_no_images(db):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,39 +48,41 @@ def test_read_root():
 
 
 @patch("cid.crud.latest_aws_image")
-@patch("cid.crud.latest_azure_image")
-@patch("cid.crud.latest_google_image")
-def test_latest_image(mock_google, mock_azure, mock_aws):
+def test_latest_aws_image(mock_aws):
     mock_aws.return_value = {
         "name": "test_image",
         "version": "1.0",
         "date": "2022-01-01",
         "amis": {"us-west-1": "ami-12345678"},
     }
-    mock_azure.return_value = {
-        "sku": "sku-a",
-        "offer": "offer-a",
-        "version": "2.0",
-        "urn": "urn-b",
-    }
-    mock_google.return_value = {
+
+    response = client.get("/aws/latest")
+    result = response.json()
+
+    assert response.status_code == 200
+    assert result["name"] == "test_image"
+    assert result["version"] == "1.0"
+    assert result["date"] == "2022-01-01"
+    assert result["amis"] == {"us-west-1": "ami-12345678"}
+
+
+@patch("cid.crud.latest_aws_image")
+def test_latest_aws_image_query_for_arch(mock_aws):
+    mock_aws.return_value = {
         "name": "test_image",
         "version": "1.0",
         "date": "2022-01-01",
-        "selfLink": "https://www.example.com",
+        "amis": {"us-west-1": "ami-12345678"},
     }
 
-    response = client.get("/latest")
+    response = client.get("/aws/latest?arch=x86_64")
     result = response.json()
 
-    assert result.keys() == {
-        "latest_aws_image",
-        "latest_azure_image",
-        "latest_google_image",
-    }
-    assert result["latest_aws_image"]["name"] == "test_image"
-    assert result["latest_azure_image"]["sku"] == "sku-a"
-    assert result["latest_google_image"]["name"] == "test_image"
+    assert response.status_code == 200
+    assert result["name"] == "test_image"
+    assert result["version"] == "1.0"
+    assert result["date"] == "2022-01-01"
+    assert result["amis"] == {"us-west-1": "ami-12345678"}
 
 
 @patch("cid.crud.find_available_versions")


### PR DESCRIPTION
Add aws/latest endpoint
Add optional arch parameter to endpoint
Remove generic /latest endpoint
Add tests for aws/latest
Add tests for aws/latest?arch=<arch>

Behavior:
Will return the newest image for all architectures supported by the cloud provider.
Can be queried using optional arch param to return a single architecture.

Example:
```
http://localhost:8000/aws/latest?arch=arm64

{
  "arm64": {
    "name": "RHEL-9.4.0_HVM-20240605-arm64-82-Hourly2-GP3",
    "version": "9.4.0",
    "date": "2024-06-07T09:52:49",
    "amis": {
      "af-south-1": "ami-0942a98ed4dd428f4",
      "ap-east-1": "ami-03fe5930b11f9c0ee",
      "ap-northeast-1": "ami-0149aa39b7b5d9e05",
      "ap-northeast-2": "ami-04c85d10b16134b5e",
      "ap-northeast-3": "ami-048b3a72ef42d8777",
      "ap-south-1": "ami-0b0ec21d6b2ce310b",
      "ap-south-2": "ami-073a954a7d4d3686a",
      "ap-southeast-1": "ami-023d6c5b3a28a2d1d",
      "ap-southeast-2": "ami-0055ffde286d1c0b6",
      "ap-southeast-3": "ami-080797a49c759836c",
      "ap-southeast-4": "ami-0896202b2cdc9525e",
      "ca-central-1": "ami-0c31a5a9fa0a1239b",
      "ca-west-1": "ami-0515912143c094899",
      "eu-central-1": "ami-02212921a6e889ed6",
      "eu-central-2": "ami-054081490abe241f2",
      "eu-north-1": "ami-096f8d910bbf871bc",
      "eu-south-1": "ami-0cc276b91c7c0e84f",
      "eu-south-2": "ami-0395cf61fa1d04470",
      "eu-west-1": "ami-02b8573b23fde21aa",
      "eu-west-2": "ami-05218761e28ba2207",
      "eu-west-3": "ami-0de19b5353afffdcb",
      "il-central-1": "ami-005d9bae884879954",
      "me-central-1": "ami-08513debf1865ed5f",
      "me-south-1": "ami-02f730ed974178987",
      "sa-east-1": "ami-0d039d995720f167e",
      "us-east-1": "ami-07472131ec292b5da",
      "us-east-2": "ami-08f9f3bb075432791",
      "us-west-1": "ami-0b6f040dfefb8e690",
      "us-west-2": "ami-05b40ce1c0e236ef2"
    }
  }
}

```