### PR TITLE
Shrink the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
+# FastAPI Docs: https://fastapi.tiangolo.com/deployment/docker/#docker-image-with-poetry
+FROM python:3.12 as requirements-stage
+WORKDIR /tmp
+RUN pip install poetry poetry-plugin-export
+COPY ./pyproject.toml ./poetry.lock* /tmp/
+RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
+
 FROM python:3.12
-# Ensure poetry does not create a virtualenv
-ENV POETRY_VIRTUALENVS_CREATE=false
-
-RUN pip install poetry
 WORKDIR /code
-COPY poetry.lock pyproject.toml /code/
-RUN poetry install --no-interaction --no-ansi --no-root --no-dev
+COPY --from=requirements-stage /tmp/requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY ./cid /code/cid
 
-COPY cid /code/cid/
-COPY import_data.py /code/
-COPY README.md /code/
-CMD ["poetry", "run", "uvicorn", "cid.main:app", "--host 0.0.0.0", "--port 80"]
+CMD ["uvicorn", "--host", "0.0.0.0", "cid.main:app"]


### PR DESCRIPTION
Use a two stage container build from the FastAPI docs to shrink the container and avoid leaving any poetry-related stuff in the resulting container. This should make the resulting container smaller and make it easier to run the app in AWS Lambda.