### PR TITLE
Add version endpoints for Azure and Google

### DIFF
--- a/cid/crud.py
+++ b/cid/crud.py
@@ -287,7 +287,7 @@ def find_matching_ami(db: Session, image_id: str) -> dict:
     }
 
 
-def find_available_versions(db: Session) -> list:
+def find_available_aws_versions(db: Session) -> list:
     """Return all RHEL versions available from AWS.
 
     It would be good to add the other providers later, but this data is so much easier
@@ -302,6 +302,35 @@ def find_available_versions(db: Session) -> list:
     """
     # Get all images with the given name.
     versions = [x.version for x in db.query(AwsImage.version).distinct()]
+
+    return sorted(versions, key=Version, reverse=True)
+
+
+def find_available_azure_versions(db: Session) -> list:
+    """Return all RHEL versions available from Azure.
+
+    Args:
+        db (Session): database session name
+    Returns:
+        list: list of available versions
+    """
+    query = db.query(AzureImage.version).distinct()
+
+    versions = [".".join(x.version.split(".")[:2]) for x in query]
+    versions = list(set(versions))
+
+    return sorted(versions, key=Version, reverse=True)
+
+
+def find_available_google_versions(db: Session) -> list:
+    """Return all RHEL versions available from Google Cloud.
+
+    Args:
+        db (Session): database session name
+    Returns:
+        list: list of available versions
+    """
+    versions = [x.version for x in db.query(GoogleImage.version).distinct()]
 
     return sorted(versions, key=Version, reverse=True)
 

--- a/cid/main.py
+++ b/cid/main.py
@@ -43,7 +43,7 @@ def latest_aws_image(db: Session = Depends(get_db), arch: Optional[str] = None) 
     return crud.latest_aws_image(db, arch)
 
 
-@app.get("/aws/{image_id}")
+@app.get("/aws/image/{image_id}")
 def single_aws_image(image_id: str, db: Session = Depends(get_db)) -> dict:  # noqa: B008
     result = db.query(AwsImage).filter(AwsImage.id == image_id).first()
     return dict(jsonable_encoder(result))
@@ -63,9 +63,19 @@ def latest_azure_image(
     return crud.latest_azure_image(db, arch)
 
 
-@app.get("/versions")
-def versions(db: Session = Depends(get_db)) -> list:  # noqa: B008
-    return crud.find_available_versions(db)
+@app.get("/aws/versions")
+def aws_versions(db: Session = Depends(get_db)) -> list:  # noqa: B008
+    return crud.find_available_aws_versions(db)
+
+
+@app.get("/azure/versions")
+def azure_versions(db: Session = Depends(get_db)) -> list:  # noqa: B008
+    return crud.find_available_azure_versions(db)
+
+
+@app.get("/google/versions")
+def google_versions(db: Session = Depends(get_db)) -> list:  # noqa: B008
+    return crud.find_available_google_versions(db)
 
 
 @repeat(every(24).hours)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -336,7 +336,7 @@ def test_find_matching_ami(db):
     ]
 
 
-def test_find_available_versions(db):
+def test_find_available_aws_versions(db):
     images = [
         AwsImage(id="ami-a", version="8.2.0"),
         AwsImage(id="ami-b", version="7.9.0"),
@@ -347,7 +347,37 @@ def test_find_available_versions(db):
     db.add_all(images)
     db.commit()
 
-    result = crud.find_available_versions(db)
+    result = crud.find_available_aws_versions(db)
+    assert result == ["10.0.0", "9.5.0", "8.2.0", "7.9.0"]
+
+
+def test_find_available_azure_versions(db):
+    images = [
+        AzureImage(id="urn-a", version="8.2.2023122216"),
+        AzureImage(id="urn-b", version="7.9.2023122216"),
+        AzureImage(id="urn-c", version="9.5.2023122216"),
+        AzureImage(id="urn-d", version="10.0.2023122216"),
+        AzureImage(id="urn-e", version="9.5.2023122216"),
+    ]
+    db.add_all(images)
+    db.commit()
+
+    result = crud.find_available_azure_versions(db)
+    assert result == ["10.0", "9.5", "8.2", "7.9"]
+
+
+def test_find_available_google_versions(db):
+    images = [
+        GoogleImage(id="id-a", version="8.2.0"),
+        GoogleImage(id="id-b", version="7.9.0"),
+        GoogleImage(id="id-c", version="9.5.0"),
+        GoogleImage(id="id-d", version="10.0.0"),
+        GoogleImage(id="id-e", version="9.5.0"),
+    ]
+    db.add_all(images)
+    db.commit()
+
+    result = crud.find_available_google_versions(db)
     assert result == ["10.0.0", "9.5.0", "8.2.0", "7.9.0"]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,11 +89,29 @@ def test_latest_aws_image_query_for_arch(mock_aws):
     assert result["amis"] == {"us-west-1": "ami-12345678"}
 
 
-@patch("cid.crud.find_available_versions")
-def test_versions(mock_versions):
+@patch("cid.crud.find_available_aws_versions")
+def test_aws_versions(mock_versions):
     mock_versions.return_value = ["8.9.0", "9.2.0", "10.0.0"]
 
-    response = client.get("/versions")
+    response = client.get("/aws/versions")
+    assert response.status_code == 200
+    assert response.json() == ["8.9.0", "9.2.0", "10.0.0"]
+
+
+@patch("cid.crud.find_available_azure_versions")
+def test_azure_versions(mock_versions):
+    mock_versions.return_value = ["8.9.0", "9.2.0", "10.0.0"]
+
+    response = client.get("/azure/versions")
+    assert response.status_code == 200
+    assert response.json() == ["8.9.0", "9.2.0", "10.0.0"]
+
+
+@patch("cid.crud.find_available_google_versions")
+def test_google_versions(mock_versions):
+    mock_versions.return_value = ["8.9.0", "9.2.0", "10.0.0"]
+
+    response = client.get("/google/versions")
     assert response.status_code == 200
     assert response.json() == ["8.9.0", "9.2.0", "10.0.0"]
 
@@ -105,7 +123,7 @@ def test_all_aws_images():
 
 
 def test_single_aws_image():
-    response = client.get("/aws/ami-08a20c15f394e5531")
+    response = client.get("/aws/image/ami-08a20c15f394e5531")
     assert response.status_code == 200
     assert response.json()["name"] == "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3"
 


### PR DESCRIPTION
Move /aws/{ami-id} to /aws/image/{ami-id} to avoid routing issues with aws/versions path Add /aws/versions
Add /azure/versions
Add /google/versions
Add necessary unit tests

@major We should discuss the routes we plan to implement in the long term so we avoid further routing issues.
I leave the /aws/image/ endpoint open for discussion as a suggestion.