### PR TITLE
Switch to sqlite -- second try

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN poetry install --no-interaction --no-ansi --no-root --no-dev
 COPY cid /code/cid/
 COPY import_data.py /code/
 COPY README.md /code/
-CMD ["poetry", "run", "uvicorn", "cid.main:app", "--host 0.0.0.0", "--port 80"]
+RUN env ENVIRONMENT=production poetry run populatedb
+CMD ["poetry", "run", "uvicorn", "--host", "0.0.0.0", "--port", "80", "cid.main:app"]

--- a/cid/bootstrap.py
+++ b/cid/bootstrap.py
@@ -1,0 +1,18 @@
+"""Functions for initial bootstrap activities."""
+
+import logging
+
+from cid.crud import update_image_data
+from cid.database import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+
+def populate_db() -> None:
+    """Populate the database with image data during container builds."""
+    logger.info("Only populating the database.")
+
+    db = SessionLocal()
+    update_image_data(db)
+
+    logger.info("Database population complete. Exiting.")

--- a/cid/config.py
+++ b/cid/config.py
@@ -7,7 +7,10 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "testing")
 
 # Database connection string.
 DATABASE_URLS = {
-    "production": "postgresql://postgres:postgres@db:5432/test_db",
+    # NOTE(mhayden): The four slashes in the production database path ensures
+    # that an absolute path is used.
+    "production": "sqlite:////cid.db",
+    # In-memory databases are much faster for testing.
     "testing": "sqlite:///:memory:",
 }
 DATABASE_URL = DATABASE_URLS[ENVIRONMENT]

--- a/cid/main.py
+++ b/cid/main.py
@@ -12,7 +12,6 @@ from cid import crud
 from cid.config import ENVIRONMENT
 from cid.database import SessionLocal
 from cid.models import AwsImage
-from cid.utils import wait_for_database
 
 log = logging.getLogger(__name__)
 
@@ -90,7 +89,6 @@ def google_versions(db: Session = Depends(get_db)) -> list:  # noqa: B008
 def self_update_image_data() -> None:
     """Update the database with new image data."""
     db = SessionLocal()
-    wait_for_database(db)
     crud.update_image_data(db)
 
 

--- a/cid/main.py
+++ b/cid/main.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional
 
 from fastapi import Depends, FastAPI
 from fastapi.encoders import jsonable_encoder
-from schedule import every, repeat, run_all, run_pending
+from schedule import every, repeat, run_pending
 from sqlalchemy.orm import Session
 
 from cid import crud
@@ -95,7 +95,6 @@ def self_update_image_data() -> None:
 
 def run_schedule() -> None:
     """Background task to run the scheduled tasks."""
-    run_all()
     while True:
         run_pending()
         sleep(1)

--- a/cid/main.py
+++ b/cid/main.py
@@ -15,6 +15,7 @@ from cid.models import AwsImage
 
 log = logging.getLogger(__name__)
 
+
 app = FastAPI()
 
 

--- a/cid/utils.py
+++ b/cid/utils.py
@@ -2,11 +2,8 @@
 
 import logging
 import re
-from time import sleep
 
 import httpx
-from sqlalchemy import text
-from sqlalchemy.orm import Session
 
 from cid.config import AWS_IMAGE_DATA, AZURE_IMAGE_DATA, GOOGLE_IMAGE_DATA
 
@@ -44,16 +41,3 @@ def extract_google_version(image_name: str) -> str:
     """Extract the RHEL version from a Google image name."""
     match = re.findall(r"rhel-(\d{1,2}(?:-arm64)*)", image_name)
     return str(match[0].replace("-", ".")) if match else ""
-
-
-def wait_for_database(db: Session) -> None:
-    """Wait for the database to be ready."""
-    test_query = text("SELECT 1")
-    while True:
-        try:
-            db.execute(test_query)
-            logger.info("Database is ready!")
-            break
-        except Exception:
-            logger.exception("Database not ready yet")
-            sleep(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,6 @@ preview = true
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101"]
+
+[tool.poetry.scripts]
+populatedb = "cid.bootstrap:populate_db"


### PR DESCRIPTION
The main idea here is to use sqlite as the production db and populate it with good data during the container build. That data can then be updated every 24 hours using our existing update mechanism without updating the container itself.