### PR TITLE
Fix arm64 error at google/versions

### DIFF
--- a/cid/crud.py
+++ b/cid/crud.py
@@ -345,7 +345,11 @@ def find_available_google_versions(db: Session) -> list:
     """
     versions = [x.version for x in db.query(GoogleImage.version).distinct()]
 
-    return sorted(versions, key=Version, reverse=True)
+    def version_key(version: str) -> Version:
+        parts = [part for part in version.split(".") if part.isdigit()]
+        return Version(".".join(parts))
+
+    return sorted(versions, key=version_key, reverse=True)
 
 
 def find_images_for_version(db: Session, version: str) -> list:

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -434,14 +434,31 @@ def test_find_available_google_versions(db):
         GoogleImage(id="id-a", version="8.2.0"),
         GoogleImage(id="id-b", version="7.9.0"),
         GoogleImage(id="id-c", version="9.5.0"),
-        GoogleImage(id="id-d", version="10.0.0"),
-        GoogleImage(id="id-e", version="9.5.0"),
+        GoogleImage(id="id-d", version="9.7.3"),
+        GoogleImage(id="id-e", version="10.0.0"),
+        GoogleImage(id="id-g", version="9.5.0"),
+        GoogleImage(id="id-h", version="9.7.arm64"),
+        GoogleImage(id="id-i", version="9.7.arm64"),
+        GoogleImage(id="id-j", version="9.arm64"),
+        GoogleImage(id="id-k", version="9.arm64"),
+        GoogleImage(id="id-l", version="9.7.1.arm64"),
+        GoogleImage(id="id-m", version="9.7.1.arm64"),
     ]
     db.add_all(images)
     db.commit()
 
     result = crud.find_available_google_versions(db)
-    assert result == ["10.0.0", "9.5.0", "8.2.0", "7.9.0"]
+
+    assert result == [
+        "10.0.0",
+        "9.7.3",
+        "9.7.1.arm64",
+        "9.7.arm64",
+        "9.5.0",
+        "9.arm64",
+        "8.2.0",
+        "7.9.0",
+    ]
 
 
 def test_find_images_for_version(db):


### PR DESCRIPTION
**Behavior**
When accessing /google/versions an error is thrown 
```
  web-1  |   File "/code/cid/main.py", line 86, in google_versions
  web-1  |     return crud.find_available_google_versions(db)
  web-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  web-1  |   File "/code/cid/crud.py", line 348, in find_available_google_versions
  web-1  |     return sorted(versions, key=Version, reverse=True)
  web-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  web-1  |   File "/usr/local/lib/python3.12/site-packages/packaging/version.py", line 202, in __init__
  web-1  |     raise InvalidVersion(f"Invalid version: '{version}'")
  web-1  | packaging.version.InvalidVersion: Invalid version: '9.arm64'
```

**Expected Behavior**
/google/versions should successfully return all unique versions, including arm64.

**Fix**
Add method to drop arm64 suffix before sorting.
Increase test coverage with edge cases and arm64 values.