### PR TITLE
Add optional params to /azure

### DIFF
--- a/cid/crud.py
+++ b/cid/crud.py
@@ -408,6 +408,39 @@ def find_aws_images(
     return paginate(query, page, page_size)
 
 
+def find_azure_images(
+    db: Session,
+    arch: Optional[str] = None,
+    version: Optional[str] = None,
+    urn: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 100,
+) -> dict:
+    """Return all Azure images that match the given criteria.
+
+    Args:
+        db (Session): database session
+        arch (Optional[str]): architecture to search
+        version (Optional[str]): RHEL version to search
+        urn (Optional[str]): image urn to search
+        page (int): page number
+        page_size (int): number of images per page
+
+    Returns:
+        list: list of images that match the given criteria
+    """
+    query = db.query(AzureImage).order_by(desc(AzureImage.version))
+
+    if arch:
+        query = query.filter(AzureImage.architecture == arch)
+    if version:
+        query = query.filter(AzureImage.version.contains(version))
+    if urn:
+        query = query.filter(AzureImage.urn.contains(urn))
+
+    return paginate(query, page, page_size)
+
+
 def paginate(
     query: Query,
     page: int = 1,

--- a/cid/main.py
+++ b/cid/main.py
@@ -63,6 +63,19 @@ def match_aws_image(image_id: str, db: Session = Depends(get_db)) -> dict:  # no
     return result
 
 
+@app.get("/azure")
+def all_azure_images(
+    db: Session = Depends(get_db),  # noqa: B008
+    arch: Optional[str] = None,
+    version: Optional[str] = None,
+    urn: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 100,
+) -> dict:
+    result = crud.find_azure_images(db, arch, version, urn, page, page_size)
+    return dict(jsonable_encoder(result))
+
+
 @app.get("/azure/latest")
 def latest_azure_image(
     db: Session = Depends(get_db),  # noqa: B008

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -638,3 +638,159 @@ def test_find_aws_images_paginated(db):
     assert result["page_size"] == 1
     assert result["total_count"] == 5
     assert result["total_pages"] == 5
+
+
+def test_find_azure_images(db):
+    images = [
+        AzureImage(
+            id="urn-a",
+            architecture="x64",
+            sku="sku-a",
+            offer="offer-a",
+            urn="urn-a",
+            version="8.2.2023122216",
+        ),
+        AzureImage(
+            id="urn-b",
+            architecture="x64",
+            sku="sku-b",
+            offer="offer-b",
+            urn="urn-b",
+            version="7.9.2023122216",
+        ),
+        AzureImage(
+            id="urn-c",
+            architecture="x64",
+            sku="sku-c",
+            offer="offer-c",
+            urn="urn-c",
+            version="9.5.2023122216",
+        ),
+        AzureImage(
+            id="urn-d",
+            architecture="x64",
+            sku="sku-d",
+            offer="offer-d",
+            urn="urn-d",
+            version="10.0.2023122216",
+        ),
+        AzureImage(
+            id="urn-e",
+            architecture="x64",
+            sku="sku-e",
+            urn="urn-e",
+            version="9.5.2023122216",
+        ),
+    ]
+    db.add_all(images)
+    db.commit()
+
+    result = crud.find_azure_images(db, None, None, None)
+    assert len(result["results"]) == 5
+
+    result = crud.find_azure_images(db, "x64", None, None)
+    assert len(result["results"]) == 5
+
+    result = crud.find_azure_images(db, None, "9.5", None)
+    assert len(result["results"]) == 2
+
+    result = crud.find_azure_images(db, None, None, "urn-c")
+    assert len(result["results"]) == 1
+
+    result = crud.find_azure_images(db, "x64", "10.0", "urn-d")
+    assert len(result["results"]) == 1
+
+
+def test_find_azure_images_paginated(db):
+    images = [
+        AzureImage(
+            id="urn-a",
+            architecture="x64",
+            sku="sku-a",
+            offer="offer-a",
+            urn="urn-a",
+            version="8.2.2023122216",
+        ),
+        AzureImage(
+            id="urn-b",
+            architecture="x64",
+            sku="sku-b",
+            offer="offer-b",
+            urn="urn-b",
+            version="7.9.2023122216",
+        ),
+        AzureImage(
+            id="urn-c",
+            architecture="x64",
+            sku="sku-c",
+            offer="offer-c",
+            urn="urn-c",
+            version="9.5.2023122216",
+        ),
+        AzureImage(
+            id="urn-d",
+            architecture="x64",
+            sku="sku-d",
+            offer="offer-d",
+            urn="urn-d",
+            version="10.0.2023122216",
+        ),
+        AzureImage(
+            id="urn-e",
+            architecture="x64",
+            sku="sku-e",
+            urn="urn-e",
+            version="9.5.2023122216",
+        ),
+    ]
+    db.add_all(images)
+    db.commit()
+
+    result = crud.find_azure_images(db, None, None, None)
+    assert len(result["results"]) == 5
+    assert result["page"] == 1
+    assert result["page_size"] == 100
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 1
+
+    result = crud.find_azure_images(db, None, None, None, 1, 1)
+    assert len(result["results"]) == 1
+    assert result["page"] == 1
+    assert result["page_size"] == 1
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 5
+
+    result = crud.find_azure_images(db, None, None, None, 2, 1)
+    assert len(result["results"]) == 1
+    assert result["page"] == 2
+    assert result["page_size"] == 1
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 5
+
+    result = crud.find_azure_images(db, None, None, None, 6, 1)
+    assert len(result["results"]) == 0
+    assert result["page"] == 6
+    assert result["page_size"] == 1
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 5
+
+    result = crud.find_azure_images(db, None, None, None, 1, 1000)
+    assert len(result["results"]) == 5
+    assert result["page"] == 1
+    assert result["page_size"] == 1000
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 1
+
+    result = crud.find_azure_images(db, None, None, None, -1, 10)
+    assert len(result["results"]) == 5
+    assert result["page"] == 1
+    assert result["page_size"] == 10
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 1
+
+    result = crud.find_azure_images(db, None, None, None, 1, -10)
+    assert len(result["results"]) == 1
+    assert result["page"] == 1
+    assert result["page_size"] == 1
+    assert result["total_count"] == 5
+    assert result["total_pages"] == 5


### PR DESCRIPTION
**Changes**
Add optional arch filter
Add optional urn filter
Add optional version filter
Add pagination
Add find_azure_images crud function
Add necessary testing

**Example**
```
http://localhost:8000/azure?arch=x64&version=9.4&urn=rhel9-gen1&page=2&page_size=1

{
  "results": [
    {
      "publisher": "RedHat",
      "id": "RedHat:rh-rhel:rh-rhel9-gen1:9.4.2024061120",
      "urn": "RedHat:rh-rhel:rh-rhel9-gen1:9.4.2024061120",
      "offer": "rh-rhel",
      "sku": "rh-rhel9-gen1",
      "architecture": "x64",
      "version": "9.4.2024061120"
    }
  ],
  "page": 2,
  "page_size": 1,
  "total_count": 4,
  "total_pages": 4
}
```