### PR TITLE
Add optional image_id param to /aws

### DIFF
--- a/cid/crud.py
+++ b/cid/crud.py
@@ -377,6 +377,7 @@ def find_aws_images(
     version: Optional[str] = None,
     name: Optional[str] = None,
     region: Optional[str] = None,
+    image_id: Optional[str] = None,
     page: int = 1,
     page_size: int = 100,
 ) -> dict:
@@ -388,11 +389,12 @@ def find_aws_images(
       version (Optional[str]): RHEL version to search
       name (Optional[str]): image name to search
       region (Optional[str]): AWS region to search
+      image_id (Optional[str]): image ID to search
       page (int): page number
       page_size (int): number of images per page
 
     Returns:
-      list: list of images that match the given criteria
+      dict: dict of images that match the given criteria
     """
     query = db.query(AwsImage).order_by(AwsImage.creationDate.desc())
 
@@ -404,6 +406,8 @@ def find_aws_images(
         query = query.filter(AwsImage.name.contains(name))
     if region:
         query = query.filter(AwsImage.region == region)
+    if image_id:
+        query = query.filter(AwsImage.id == image_id)
 
     return paginate(query, page, page_size)
 

--- a/cid/main.py
+++ b/cid/main.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 from cid import crud
 from cid.config import ENVIRONMENT
 from cid.database import SessionLocal
-from cid.models import AwsImage
 
 log = logging.getLogger(__name__)
 
@@ -39,22 +38,19 @@ def all_aws_images(
     version: Optional[str] = None,
     name: Optional[str] = None,
     region: Optional[str] = None,
+    image_id: Optional[str] = None,
     page: int = 1,
     page_size: int = 100,
 ) -> dict:
-    result = crud.find_aws_images(db, arch, version, name, region, page, page_size)
+    result = crud.find_aws_images(
+        db, arch, version, name, region, image_id, page, page_size
+    )
     return dict(jsonable_encoder(result))
 
 
 @app.get("/aws/latest")
 def latest_aws_image(db: Session = Depends(get_db), arch: Optional[str] = None) -> dict:  # noqa: B008
     return crud.latest_aws_image(db, arch)
-
-
-@app.get("/aws/image/{image_id}")
-def single_aws_image(image_id: str, db: Session = Depends(get_db)) -> dict:  # noqa: B008
-    result = db.query(AwsImage).filter(AwsImage.id == image_id).first()
-    return dict(jsonable_encoder(result))
 
 
 @app.get("/aws/match/{image_id}")

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -521,16 +521,16 @@ def test_find_aws_images(db):
     db.add_all(images)
     db.commit()
 
-    result = crud.find_aws_images(db, None, None, None, None)
+    result = crud.find_aws_images(db, None, None, None, None, None)
     assert len(result["results"]) == 5
 
-    result = crud.find_aws_images(db, "arm64", None, None, None)
+    result = crud.find_aws_images(db, "arm64", None, None, None, None)
     assert len(result["results"]) == 1
     assert result["results"][0].name == "RHEL-9.5.0"
     assert result["results"][0].arch == "arm64"
     assert result["results"][0].region == "us-west-2"
 
-    result = crud.find_aws_images(db, None, "9.5.0", None, None)
+    result = crud.find_aws_images(db, None, "9.5.0", None, None, None)
     assert len(result["results"]) == 2
     assert result["results"][0].name == "RHEL-9.5.0"
     assert result["results"][0].arch == "x86_64"
@@ -539,14 +539,17 @@ def test_find_aws_images(db):
     assert result["results"][1].arch == "arm64"
     assert result["results"][1].region == "us-west-2"
 
-    result = crud.find_aws_images(db, None, None, "10.0.0", None)
+    result = crud.find_aws_images(db, None, None, "10.0.0", None, None)
     assert len(result["results"]) == 1
     assert result["results"][0].name == "RHEL-10.0.0"
     assert result["results"][0].arch == "x86_64"
     assert result["results"][0].region == "us-west-2"
 
-    result = crud.find_aws_images(db, None, None, None, "us-west-1")
+    result = crud.find_aws_images(db, None, None, None, "us-west-1", None)
     assert len(result["results"]) == 3
+
+    result = crud.find_aws_images(db, None, None, None, None, "ami-a")
+    assert len(result["results"]) == 1
 
 
 def test_find_aws_images_paginated(db):
@@ -590,49 +593,49 @@ def test_find_aws_images_paginated(db):
     db.add_all(images)
     db.commit()
 
-    result = crud.find_aws_images(db, None, None, None, None)
+    result = crud.find_aws_images(db, None, None, None, None, None)
     assert len(result["results"]) == 5
     assert result["page"] == 1
     assert result["page_size"] == 100
     assert result["total_count"] == 5
     assert result["total_pages"] == 1
 
-    result = crud.find_aws_images(db, None, None, None, None, 1, 1)
+    result = crud.find_aws_images(db, None, None, None, None, None, 1, 1)
     assert len(result["results"]) == 1
     assert result["page"] == 1
     assert result["page_size"] == 1
     assert result["total_count"] == 5
     assert result["total_pages"] == 5
 
-    result = crud.find_aws_images(db, None, None, None, None, 2, 1)
+    result = crud.find_aws_images(db, None, None, None, None, None, 2, 1)
     assert len(result["results"]) == 1
     assert result["page"] == 2
     assert result["page_size"] == 1
     assert result["total_count"] == 5
     assert result["total_pages"] == 5
 
-    result = crud.find_aws_images(db, None, None, None, None, 6, 1)
+    result = crud.find_aws_images(db, None, None, None, None, None, 6, 1)
     assert len(result["results"]) == 0
     assert result["page"] == 6
     assert result["page_size"] == 1
     assert result["total_count"] == 5
     assert result["total_pages"] == 5
 
-    result = crud.find_aws_images(db, None, None, None, None, 1, 1000)
+    result = crud.find_aws_images(db, None, None, None, None, None, 1, 1000)
     assert len(result["results"]) == 5
     assert result["page"] == 1
     assert result["page_size"] == 1000
     assert result["total_count"] == 5
     assert result["total_pages"] == 1
 
-    result = crud.find_aws_images(db, None, None, None, None, -1, 10)
+    result = crud.find_aws_images(db, None, None, None, None, None, -1, 10)
     assert len(result["results"]) == 5
     assert result["page"] == 1
     assert result["page_size"] == 10
     assert result["total_count"] == 5
     assert result["total_pages"] == 1
 
-    result = crud.find_aws_images(db, None, None, None, None, 1, -10)
+    result = crud.find_aws_images(db, None, None, None, None, None, 1, -10)
     assert len(result["results"]) == 1
     assert result["page"] == 1
     assert result["page_size"] == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,6 +167,15 @@ def test_all_aws_images_with_query_name():
     )
 
 
+def test_all_aws_images_with_query_image_id():
+    response = client.get("/aws?image_id=ami-08a20c15f394e5531")
+    assert response.status_code == 200
+    assert (
+        response.json()["results"][0]["name"]
+        == "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3"
+    )
+
+
 def test_all_aws_images_with_query_combination():
     response = client.get(
         "/aws"
@@ -174,6 +183,7 @@ def test_all_aws_images_with_query_combination():
         + "&region=af-south-1"
         + "&version=9.4.0"
         + "&arch=x86_64"
+        + "&image_id=ami-08a20c15f394e5531"
     )
     assert response.status_code == 200
     assert len(response.json()["results"]) == 1
@@ -196,12 +206,6 @@ def test_all_aws_images_with_query_combination_no_match():
     )
     assert response.status_code == 200
     assert len(response.json()["results"]) == 0
-
-
-def test_single_aws_image():
-    response = client.get("/aws/image/ami-08a20c15f394e5531")
-    assert response.status_code == 200
-    assert response.json()["name"] == "RHEL_HA-9.4.0_HVM-20240605-x86_64-82-Hourly2-GP3"
 
 
 def test_match_aws_image():


### PR DESCRIPTION
**Changes**
Add necessary testing
Drop /aws/image/{image_id}

**Example**
```
http://localhost:8000/aws?image_id=ami-038e962eca80132d7

{
  "results": [
    {
      "name": "RHEL_HA-8.8.0_HVM-20240605-x86_64-32-Hourly2-GP3",
      "id": "ami-038e962eca80132d7",
      "version": "8.8.0",
      "date": "2024-06-11T18:36:14",
      "region": "us-east-2",
      "creationDate": "2024-06-11T18:36:14",
      "imageId": "ami-038e962eca80132d7",
      "arch": "x86_64",
      "provider": "amazon",
      "description": "Provided by Red Hat, Inc.",
      "deprecationTime": "2026-06-11T18:36:14"
    }
  ],
  "page": 1,
  "page_size": 100,
  "total_count": 1,
  "total_pages": 1
}
```