### PR TITLE
Add metadata to root route

### DIFF
--- a/cid/bootstrap.py
+++ b/cid/bootstrap.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from cid.crud import update_image_data
+from cid.crud import update_image_data, update_last_updated
 from cid.database import SessionLocal
 
 logger = logging.getLogger(__name__)
@@ -14,5 +14,6 @@ def populate_db() -> None:
 
     db = SessionLocal()
     update_image_data(db)
+    update_last_updated(db)
 
     logger.info("Database population complete. Exiting.")

--- a/cid/models.py
+++ b/cid/models.py
@@ -1,6 +1,6 @@
 """Database models."""
 
-from sqlalchemy import JSON, Column, DateTime, Integer, String
+from sqlalchemy import JSON, Column, DateTime, Integer, String, func
 
 from cid.database import Base
 
@@ -57,3 +57,10 @@ class AzureImage(Base):
     sku = Column(String)
     urn = Column(String)
     version = Column(String)
+
+
+class LastUpdate(Base):
+    __tablename__ = "last_update"
+
+    id = Column(Integer, primary_key=True)
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -7,6 +7,15 @@ from cid import crud
 from cid.models import AwsImage, AzureImage, GoogleImage
 
 
+def test_last_update(db):
+    result = crud.get_last_update(db)
+    assert result == ""
+
+    crud.update_last_updated(db)
+    result = crud.get_last_update(db)
+    assert datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
+
+
 def test_latest_aws_image_no_images(db):
     result = crud.latest_aws_image(db, None)
     assert result == {"error": "No images found for AWS.", "code": 404}


### PR DESCRIPTION
**Summary**
The CIDv2 root route can easily be used to show service related information.
This is a baseline implementation that adds reports on
- system status 
- last data refresh
- additional services (docs)

**Changes**
Add new table for update timestamp
Add crud functions for updating and reading db update timestamp
Extend root route data set with endpoint status, docs link and update timestamp
Add timestamp update to bootstrap.py 
Add testing for db update timestamp
Add testing for root route

**Example Output**
```
{
  "status": {
    "http://localhost:8000/aws": "running",
    "http://localhost:8000/google": "running",
    "http://localhost:8000/azure": "running"
  },
  "docs": "http://localhost:8000/docs",
  "last_update": "2024-07-05T05:56:42"
}
```